### PR TITLE
Have built a docker image for edrixs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git/
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,65 @@
+FROM ubuntu
+WORKDIR /project
+
+RUN apt-get update \
+    # add user rixs
+    && apt-get install -y sudo \
+    && useradd -ms /bin/bash rixs \
+    && echo "rixs:rixs" | chpasswd \
+    && adduser rixs sudo \
+    # turn off the error reports from openmpi
+    && echo "export OMPI_MCA_btl_vader_single_copy_mechanism=none" >> ~/.bashrc  \
+    && echo "export OMPI_MCA_btl_vader_single_copy_mechanism=none" >> /home/rixs/.bashrc \
+    # install deps 
+    && apt-get install -y gcc libgcc-7-dev g++ gfortran ssh wget vim libtool autoconf make \
+    && apt-get install -y python3 libpython3-dev python3-pip ipython3 \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3 10 \
+    && update-alternatives --install /usr/bin/ipython ipython /usr/bin/ipython3 10 \
+    && update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10 \
+    # install openblas
+    && wget https://github.com/xianyi/OpenBLAS/archive/v0.3.6.tar.gz \
+    && tar -xzf v0.3.6.tar.gz \
+    && make -C OpenBLAS-0.3.6 CC=gcc FC=gfortran \
+    && make -C OpenBLAS-0.3.6 PREFIX=/usr/local install \
+    && rm -rf OpenBLAS-0.3.6 v0.3.6.tar.gz \
+    # install openmpi
+    && wget https://download.open-mpi.org/release/open-mpi/v3.1/openmpi-3.1.4.tar.bz2 \
+    && tar -xjf openmpi-3.1.4.tar.bz2 \
+    && cd openmpi-3.1.4 \
+    && ./configure CC=gcc CXX=g++ FC=gfortran \
+    && make  \
+    && make install  \
+    && cd ..  \
+    && rm -rf openmpi-3.1.4 openmpi-3.1.4.tar.bz2
+    # install arpack-ng
+RUN wget https://github.com/opencollab/arpack-ng/archive/3.6.3.tar.gz \
+    && tar -xzf 3.6.3.tar.gz \
+    && cd arpack-ng-3.6.3 \
+    && export LD_LIBRARY_PATH="/usr/local/lib:\$LD_LIBRARY_PATH" \
+    && ./bootstrap \
+    && ./configure --enable-mpi --with-blas="-L/usr/local/lib/ -lopenblas" FC=gfortran F77=gfortran MPIFC=mpif90 MPIF77=mpif90  \
+    && make \
+    && make install \
+    && cd .. \
+    && rm -rf arpack-ng-3.6.3 3.6.3.tar.gz \
+    # install numpy
+    && pip install numpy 
+
+COPY . ./src/edrixs
+
+    # build fortran part of edrixs
+RUN export LD_LIBRARY_PATH="/usr/local/lib:\$LD_LIBRARY_PATH" \
+    && make -C src/edrixs/src F90=mpif90 LIBS="-L/usr/local/lib -lopenblas -lparpack -larpack" \
+    && make install -C src/edrixs/src \
+    # build python part of edrixs
+    && cd src/edrixs \
+    && python setup.py build --library-dirs=/usr/local/lib \
+    && pip install . \
+    && cd ../../  \
+    # set env
+    && cp -r src/edrixs/examples /home/rixs/edrixs_examples \
+    && chown -R rixs:rixs /home/rixs/edrixs_examples \
+    && echo "export PATH=/project/src/edrixs/bin:\$PATH" >> ~/.bashrc  \
+    && echo "export PATH=/project/src/edrixs/bin:\$PATH" >> /home/rixs/.bashrc  \
+    && echo "export LD_LIBRARY_PATH=/usr/local/lib:\$LD_LIBRARY_PATH" >> ~/.bashrc  \
+    && echo "export LD_LIBRARY_PATH=/usr/local/lib:\$LD_LIBRARY_PATH" >> /home/rixs/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,13 @@ RUN wget https://github.com/opencollab/arpack-ng/archive/3.6.3.tar.gz \
     && make install \
     && cd .. \
     && rm -rf arpack-ng-3.6.3 3.6.3.tar.gz \
-    # install numpy
-    && pip install numpy 
+    # install python deps
+    && pip install numpy scipy sympy matplotlib sphinx mpi4py \
+    # set env
+    && echo "export PATH=/project/src/edrixs/bin:\$PATH" >> ~/.bashrc  \
+    && echo "export PATH=/project/src/edrixs/bin:\$PATH" >> /home/rixs/.bashrc  \
+    && echo "export LD_LIBRARY_PATH=/usr/local/lib:\$LD_LIBRARY_PATH" >> ~/.bashrc  \
+    && echo "export LD_LIBRARY_PATH=/usr/local/lib:\$LD_LIBRARY_PATH" >> /home/rixs/.bashrc
 
 COPY . ./src/edrixs
 
@@ -53,13 +58,9 @@ RUN export LD_LIBRARY_PATH="/usr/local/lib:\$LD_LIBRARY_PATH" \
     && make install -C src/edrixs/src \
     # build python part of edrixs
     && cd src/edrixs \
-    && python setup.py build --library-dirs=/usr/local/lib \
+    && python setup.py build_ext --library-dirs=/usr/local/lib \
     && pip install . \
     && cd ../../  \
-    # set env
+    # copy examples to /home/rixs
     && cp -r src/edrixs/examples /home/rixs/edrixs_examples \
     && chown -R rixs:rixs /home/rixs/edrixs_examples \
-    && echo "export PATH=/project/src/edrixs/bin:\$PATH" >> ~/.bashrc  \
-    && echo "export PATH=/project/src/edrixs/bin:\$PATH" >> /home/rixs/.bashrc  \
-    && echo "export LD_LIBRARY_PATH=/usr/local/lib:\$LD_LIBRARY_PATH" >> ~/.bashrc  \
-    && echo "export LD_LIBRARY_PATH=/usr/local/lib:\$LD_LIBRARY_PATH" >> /home/rixs/.bashrc

--- a/README.rst
+++ b/README.rst
@@ -76,29 +76,30 @@ To make life easier, we have built a docker image based on Ubuntu Linux (18.04) 
 The docker image can be used on any OS as long as the `docker <https://www.docker.com/>`_ application are available.
 Follow these steps to use the docker image:
 
-   * Install the `docker <https://www.docker.com/>`_ application on your system and `learn how to use it <https://docs.docker.com/get-started/>`_.
-   * Once the docker is running, create a directory to store data in your host OS and launch a container to run edrixs
+* Install the `docker <https://www.docker.com/>`_ application on your system and `learn how to use it <https://docs.docker.com/get-started/>`_.
+* Once the docker is running, create a directory to store data in your host OS and launch a container to run edrixs
 
-      .. code-block:: bash
+  .. code-block:: bash
       
-         $ mkdir /dir/on/your/host/os   # A directory on your host OS
-         $ docker run -it -u rixs -w /home/rixs -v /dir/on/your/host/os:/home/rixs/data laowang2017/edrixs
-         # in the container
-         $ cd /home/rixs/data
-         $ cp -r ../edrixs_examples .
-         $ Play with edrixs ... 
+     $ mkdir /dir/on/your/host/os   # A directory on your host OS
+     $ docker run -it -u rixs -w /home/rixs -v /dir/on/your/host/os:/home/rixs/data laowang2017/edrixs
+     # in the container
+     $ cd /home/rixs/data
+     $ cp -r ../edrixs_examples .
+     $ Play with edrixs ... 
 
-   * "-u rixs" means use a default user **rixs** to login the Ubuntu Linux, the password of the user **rixs** is: `rixs`. 
-   * "-v /dir/on/your/host/os:/home/rixs/data" means mount the directory "/dir/on/your/host/os" on your host OS to    "/home/rixs/data" on this virtual Ubuntu Linux in the container. 
+* "-u rixs" means use a default user **rixs** to login the Ubuntu Linux, the password of the user **rixs** is: `rixs`. 
+* "-v /dir/on/your/host/os:/home/rixs/data" means mount the directory "/dir/on/your/host/os" on your host OS to    "/home/rixs/data" on this virtual Ubuntu Linux in the container. 
    
-   After launching the container, you will see **data** and **edrixs_examples** in "/home/rixs" directory. If you want to save the data from edrixs calculations to your host system, you need to work in "/home/rixs/data" directory and the changes can be seen in the directory "/dir/on/your/host/os" on your host system. 
-   Note that any changes outside "/home/rixs/data" will lost when this container stops. You can only use your host OS to make interactive plots. Use "sudo apt-get install" to install softwares if they are needed. Type **exit** in the container to exit. You can delete the stopped containers by
+After launching the container, you will see **data** and **edrixs_examples** in "/home/rixs" directory. If you want to save the data from edrixs calculations to your host system, you need to work in "/home/rixs/data" directory and the changes can be seen in the directory "/dir/on/your/host/os" on your host system. 
+
+Note that any changes outside "/home/rixs/data" will lost when this container stops. You can only use your host OS to make interactive plots. Use "sudo apt-get install" to install softwares if they are needed. Type **exit** in the container to exit. You can delete the stopped containers by
 
    .. code-block:: bash
       
       $ docker rm $(docker ps -a -q)
 
-   You can delete the edrixs image if you don't want to play with it anymore,
+You can delete the edrixs image if you don't want to play with it anymore,
 
    .. code-block:: bash
    

--- a/README.rst
+++ b/README.rst
@@ -26,12 +26,12 @@ Installation
 ------------
 * Required tools and libraries
 
-   * gfortran or ifort 
-   * MPI environment (openmpi or mpich)
-   * mpif90 (binding with gfortran or ifort)
+   * Fortran compiler: gfortran and ifort are supported 
+   * MPI environment: openmpi and mpich are tested
+   * mpif90 (binding with gfortran or ifort) and mpicc (binding with gcc)
    * Python3
-   * BLAS and LAPACK (gfortran+OpenBLAS or ifort+MKL)
-   * arpack-ng (enable mpi)
+   * BLAS and LAPACK: gfortran+OpenBLAS or ifort+MKL
+   * arpack-ng (with mpi enabled)
    * Numpy
    * Scipy
    * Sympy
@@ -40,7 +40,7 @@ Installation
    * Sphinx
    * Numpydoc
 
-  Be sure to compile OpenBLAS, arpack-ng, mpi4py and edrixs with the same Fortran (MPI) compiler.
+  Be sure to compile OpenBLAS, arpack-ng, mpi4py and edrixs with the same (MPI) Fortran compiler.
 
 * Install Fortran parts of edrixs
 
@@ -50,7 +50,7 @@ Installation
        $ make F90=mpif90 LIBS="-L/usr/local/lib -lopenblas -lparpack -larpack"
        $ make install
 
-  where, you may need to change **F90** and **LIBS** according to your specific environment. There will be problems when using gfortran with MKL, so we recommend gfortran+OpenBLAS or ifort+MKL. libedrixsfortran.a will be generated, which will be used when building python interface. The executable .x files will be installed in bin directory and add the following line in .bashrc or .bash_profile file,
+  where, you may need to change ``F90`` and ``LIBS`` according to your specific environment. There will be problems when using gfortran with MKL, so we recommend ``gfortran+OpenBLAS`` or ``ifort+MKL``. ``libedrixsfortran.a`` will be generated, which will be used when building python interface. The executable ``.x`` files will be installed in ``edrixs/bin`` directory and add the following line in ``.bashrc`` or ``.bash_profile`` file,
 
     .. code-block:: bash
 
@@ -58,7 +58,7 @@ Installation
 
 * Install Python parts of edrixs
 
-  Be sure to first make libedrixsfortran.a in src.
+  Be sure to first make ``libedrixsfortran.a`` in src.
 
     .. code-block:: bash
 
@@ -67,7 +67,7 @@ Installation
          --link-objects=./src/libedrixsfortran.a
        $ pip install .
 
-  where, **--library-dirs** ares the paths to search **--libraries**, please set it according to your environments.
+  where, ``--library-dirs`` ares the paths to search ``--libraries``, please set it according to your environments.
 
 
 Run edrixs in docker

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ Installation
 
     .. code-block:: bash
 
-       export PATH=edrixs/bin:$PATH
+       export PATH=/root_dir_of_edrixs/edrixs/bin:$PATH
 
 * Install Python parts of edrixs
 

--- a/README.rst
+++ b/README.rst
@@ -79,24 +79,30 @@ Follow these steps to use the docker image:
    * Install the `docker <https://www.docker.com/>`_ application on your system and `learn how to use it <https://docs.docker.com/get-started/>`_.
    * Once the docker is running, create a directory to store data in your host OS and launch a container to run edrixs
 
+      .. code-block:: bash
+      
+         $ mkdir /dir/on/your/host/os   # A directory on your host OS
+         $ docker run -it -u rixs -w /home/rixs -v /dir/on/your/host/os:/home/rixs/data laowang2017/edrixs
+         # in the container
+         $ cd /home/rixs/data
+         $ cp -r ../edrixs_examples .
+         $ Play with edrixs ... 
+
+   * "-u rixs" means use a default user **rixs** to login the Ubuntu Linux, the password of the user **rixs** is: `rixs`. 
+   * "-v /dir/on/your/host/os:/home/rixs/data" means mount the directory "/dir/on/your/host/os" on your host OS to    "/home/rixs/data" on this virtual Ubuntu Linux in the container. 
+   
+   After launching the container, you will see **data** and **edrixs_examples** in "/home/rixs" directory. If you want to save the data from edrixs calculations to your host system, you need to work in "/home/rixs/data" directory and the changes can be seen in the directory "/dir/on/your/host/os" on your host system. 
+   Note that any changes outside "/home/rixs/data" will lost when this container stops. You can only use your host OS to make interactive plots. Use "sudo apt-get install" to install softwares if they are needed. Type **exit** in the container to exit. You can delete the stopped containers by
+
    .. code-block:: bash
       
-      mkdir /dir/on/your/host/os   # A directory on your host OS
-      docker run -it -u rixs -w /home/rixs -v /dir/on/your/host/os:/home/rixs/data laowang2017/edrixs
-      cd /home/rixs/data
-      cp -r ../edrixs_examples .
-      Play with edrixs ... 
-
-   where, **-u rixs** means use a default user **rixs** to login the Ubuntu Linux, the password of the user **rixs** is: `rixs`. **-v /dir/on/your/host/os:/home/rixs/data** means mount the directory `/dir/on/your/host/os` on your host OS to `/home/rixs/data` on this virtual Ubuntu Linux in the container. After launching the container, you will see **data** and**edrixs_examples** in `/home/rixs` directory. If you want to save the data from edrixs calculations to your host system, you need to work in `/home/rixs/data` directory and the changes can be seen in the directory `/dir/on/your/host/os` on your host system. Note that any changes outside `/home/rixs/data` will lost when this container stops. You can only use your host OS to make interactive plots. Use `sudo apt-get install` to install softwares if they are needed. Type `exit` in the container to exit. You can delete the stopped containers by
-
-   .. code-block:: bash
-      
-      docker rm $(docker ps -a -q)
+      $ docker rm $(docker ps -a -q)
 
    You can delete the edrixs image if you don't want to play with it anymore,
 
    .. code-block:: bash
-      docker rmi laowang2017/edrixs   
+   
+      $ docker rmi laowang2017/edrixs   
 
 
 How to cite

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 edrixs
 ===============================
 
-.. image:: https://img.shields.io/travis/mrakitin/edrixs.svg
-        :target: https://travis-ci.org/mrakitin/edrixs
+.. image:: https://img.shields.io/travis/NSLS-II/edrixs.svg
+        :target: https://travis-ci.org/NSLS-II/edrixs
 
 .. image:: https://img.shields.io/pypi/v/edrixs.svg
         :target: https://pypi.python.org/pypi/edrixs
@@ -72,7 +72,7 @@ Installation
 
 Run edrixs in docker
 --------------------
-To make life easier, we have built a docker image based on Ubuntu Linux (18.04) for edrixs, so you don't need to struggle with the installation anymore.
+To make life easier, we have built a docker image based on Ubuntu Linux (18.04) for edrixs, so you don't need to struggle with the installation anymore. 
 The docker image can be used on any OS as long as the `docker <https://www.docker.com/>`_ application are available.
 Follow these steps to use the docker image:
 
@@ -88,18 +88,18 @@ Follow these steps to use the docker image:
      $ cp -r ../edrixs_examples .
      $ Play with edrixs ... 
 
-* "-u rixs" means use a default user **rixs** to login the Ubuntu Linux, the password of the user **rixs** is: `rixs`. 
-* "-v /dir/on/your/host/os:/home/rixs/data" means mount the directory "/dir/on/your/host/os" on your host OS to    "/home/rixs/data" on this virtual Ubuntu Linux in the container. 
+* "-u rixs" means using a default user *rixs* to login the Ubuntu Linux, the password is *rixs*. 
+* "-v /dir/on/your/host/os:/home/rixs/data" means mounting the directory "/dir/on/your/host/os" from your host OS to    "/home/rixs/data" on the Ubuntu Linux in the container. 
    
-After launching the container, you will see **data** and **edrixs_examples** in "/home/rixs" directory. If you want to save the data from edrixs calculations to your host system, you need to work in "/home/rixs/data" directory and the changes can be seen in the directory "/dir/on/your/host/os" on your host system. 
+After launching the container, you will see *data* and *edrixs_examples* in "/home/rixs" directory. If you want to save the data from edrixs calculations to your host system, you need to work in "/home/rixs/data" directory.
 
-Note that any changes outside "/home/rixs/data" will lost when this container stops. You can only use your host OS to make interactive plots. Use "sudo apt-get install" to install softwares if they are needed. Type **exit** in the container to exit. You can delete the stopped containers by
+Note that any changes outside "/home/rixs/data" will lost when this container stops. You can only use your host OS to make interactive plots. Use "sudo apt-get install" to install softwares if they are needed. Type *exit* in the container to exit. You can delete all the stopped containers by
 
    .. code-block:: bash
       
       $ docker rm $(docker ps -a -q)
 
-You can delete the edrixs image if you don't want to play with it anymore,
+You can delete the edrixs image by
 
    .. code-block:: bash
    

--- a/README.rst
+++ b/README.rst
@@ -47,15 +47,10 @@ Installation
     .. code-block:: bash
 
        $ cd src
-
-  edit make.sys to set the correct libraries of BLAS/LAPACK, arpack-ng and f2py compiler options.
-
-    .. code-block:: bash
-
-       $ make
+       $ make F90=mpif90 LIBS="-L/usr/local/lib -lopenblas -lparpack -larpack"
        $ make install
 
-  There will be problems when using gfortran and f2py with MKL, so we recommend gfortran+OpenBLAS or ifort+MKL. libedrixsfortran.a will be generated, which will be used when building python interface. The executable .x files will be installed in bin directory and add the following line in .bashrc or .bash_profile file,
+  where, you may need to change **F90** and **LIBS** according to your specific environment. There will be problems when using gfortran with MKL, so we recommend gfortran+OpenBLAS or ifort+MKL. libedrixsfortran.a will be generated, which will be used when building python interface. The executable .x files will be installed in bin directory and add the following line in .bashrc or .bash_profile file,
 
     .. code-block:: bash
 
@@ -68,11 +63,40 @@ Installation
     .. code-block:: bash
 
        $ python setup.py config_fc --f77exec=mpif90 --f90exec=mpif90 build_ext \
-         --libraries=openblas,parpack,arpack --library-dirs=/usr/lib:/opt/local/lib \
+         --libraries=openblas,parpack,arpack --library-dirs=/usr/lib:/usr/local/lib:/opt/local/lib \
          --link-objects=./src/libedrixsfortran.a
        $ pip install .
 
   where, **--library-dirs** ares the paths to search **--libraries**, please set it according to your environments.
+
+
+Run edrixs in docker
+--------------------
+To make life easier, we have built a docker image based on Ubuntu Linux (18.04) for edrixs, so you don't need to struggle with the installation anymore.
+The docker image can be used on any OS as long as the `docker <https://www.docker.com/>`_ application are available.
+Follow these steps to use the docker image:
+
+   * Install the `docker <https://www.docker.com/>`_ application on your system and `learn how to use it <https://docs.docker.com/get-started/>`_.
+   * Once the docker is running, create a directory to store data in your host OS and launch a container to run edrixs
+
+   .. code-block:: bash
+      
+      mkdir /dir/on/your/host/os   # A directory on your host OS
+      docker run -it -u rixs -w /home/rixs -v /dir/on/your/host/os:/home/rixs/data laowang2017/edrixs
+      cd /home/rixs/data
+      cp -r ../edrixs_examples .
+      Play with edrixs ... 
+
+   where, **-u rixs** means use a default user **rixs** to login the Ubuntu Linux, the password of the user **rixs** is: `rixs`. **-v /dir/on/your/host/os:/home/rixs/data** means mount the directory `/dir/on/your/host/os` on your host OS to `/home/rixs/data` on this virtual Ubuntu Linux in the container. After launching the container, you will see **data** and**edrixs_examples** in `/home/rixs` directory. If you want to save the data from edrixs calculations to your host system, you need to work in `/home/rixs/data` directory and the changes can be seen in the directory `/dir/on/your/host/os` on your host system. Note that any changes outside `/home/rixs/data` will lost when this container stops. You can only use your host OS to make interactive plots. Use `sudo apt-get install` to install softwares if they are needed. Type `exit` in the container to exit. You can delete the stopped containers by
+
+   .. code-block:: bash
+      
+      docker rm $(docker ps -a -q)
+
+   You can delete the edrixs image if you don't want to play with it anymore,
+
+   .. code-block:: bash
+      docker rmi laowang2017/edrixs   
 
 
 How to cite

--- a/README.rst
+++ b/README.rst
@@ -79,14 +79,14 @@ Follow these steps to use the docker image:
 * Install the `docker <https://www.docker.com/>`_ application on your system and `learn how to use it <https://docs.docker.com/get-started/>`_.
 * Once the docker is running, create a directory to store data in your host OS and launch a container to run edrixs
 
-  .. code-block:: bash
+    .. code-block:: bash
       
-     $ mkdir /dir/on/your/host/os   # A directory on your host OS
-     $ docker run -it -u rixs -w /home/rixs -v /dir/on/your/host/os:/home/rixs/data laowang2017/edrixs
-     # in the container
-     $ cd /home/rixs/data
-     $ cp -r ../edrixs_examples .
-     $ Play with edrixs ... 
+       $ mkdir /dir/on/your/host/os   # A directory on your host OS
+       $ docker run -it -u rixs -w /home/rixs -v /dir/on/your/host/os:/home/rixs/data laowang2017/edrixs
+       # in the container
+       $ cd /home/rixs/data
+       $ cp -r ../edrixs_examples .
+       $ Play with edrixs ... 
 
 * "-u rixs" means using a default user *rixs* to login the Ubuntu Linux, the password is *rixs*. 
 * "-v /dir/on/your/host/os:/home/rixs/data" means mounting the directory "/dir/on/your/host/os" from your host OS to    "/home/rixs/data" on the Ubuntu Linux in the container. 

--- a/README.rst
+++ b/README.rst
@@ -83,23 +83,29 @@ Follow these steps to use the docker image:
       
        $ mkdir /dir/on/your/host/os   # A directory on your host OS
        $ docker run -it -u rixs -w /home/rixs -v /dir/on/your/host/os:/home/rixs/data laowang2017/edrixs
-       # in the container
+       
+  it will take a while to pull the image from `Docker Hub <https://cloud.docker.com/repository/docker/laowang2017/edrixs/>`_ for the first time, while, it will launch the local one very fast at the next time.
+  
+  * ``-u rix`` means using a default user ``rixs`` to login the Ubuntu Linux, the password is ``rixs``. 
+  * ``-v /dir/on/your/host/os:/home/rixs/dat`` means mounting the directory ``/dir/on/your/host/os`` from your host OS to    ``/home/rixs/data`` on the Ubuntu Linux in the container. 
+   
+* After launching the container, you will see ``data`` and ``edrixs_examples`` in ``/home/rixs`` directory. If you want to save the data from edrixs calculations to your host system, you need to work in ``/home/rixs/data`` directory.
+
+    .. code-block:: bash
+    
        $ cd /home/rixs/data
        $ cp -r ../edrixs_examples .
        $ Play with edrixs ... 
 
-* "-u rixs" means using a default user *rixs* to login the Ubuntu Linux, the password is *rixs*. 
-* "-v /dir/on/your/host/os:/home/rixs/data" means mounting the directory "/dir/on/your/host/os" from your host OS to    "/home/rixs/data" on the Ubuntu Linux in the container. 
-   
-After launching the container, you will see *data* and *edrixs_examples* in "/home/rixs" directory. If you want to save the data from edrixs calculations to your host system, you need to work in "/home/rixs/data" directory.
-
-Note that any changes outside "/home/rixs/data" will lost when this container stops. You can only use your host OS to make interactive plots. Use "sudo apt-get install" to install softwares if they are needed. Type *exit* in the container to exit. You can delete all the stopped containers by
+  Note that any changes outside ``/home/rixs/data`` will lost when this container stops. You can only use your host OS to make interactive plots. Use ``sudo apt-get install`` to install softwares if they are needed. 
+  
+* Type ``exit`` in the container to exit. You can delete all the stopped containers by
 
    .. code-block:: bash
       
       $ docker rm $(docker ps -a -q)
 
-You can delete the edrixs image by
+* You can delete the edrixs image by
 
    .. code-block:: bash
    


### PR DESCRIPTION
A docker image for edrixs has been built based on Ubuntu Linux (18.04). Now, users can try or learn edrixs on their laptops without worrying about the installation.  The image can be run on any OS where docker is supported. The image can be pulled from my docker hub account: [docker hub account](https://hub.docker.com/r/laowang2017/edrixs) by

`$ docker pull laowang2017/edrixs`

A container can be launched by

`$ docker run -it -u rixs -w /home/rixs -v /dir/on/your/host/os:/home/rixs/data laowang2017/edrixs`

The docker image can be (automatically) updated based on github repo by

`$ docker image build -t laowang2017/edrixs https://github.com/NSLS-II/edrixs.git#master`