### PR TITLE
Simplify apis

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,7 @@ Follow these steps to use the docker image:
        $ cp -r ../edrixs_examples .
        $ Play with edrixs ... 
 
-  Note that any changes outside ``/home/rixs/data`` will lost when this container stops. You can only use your host OS to make interactive plots. Use ``sudo apt-get install`` to install softwares if they are needed. 
+  Note that any changes outside ``/home/rixs/data`` will be lost when this container stops. You can only use your host OS to make interactive plots. Use ``sudo apt-get install`` to install softwares if they are needed. 
   
 * Type ``exit`` in the container to exit. You can delete all the stopped containers by
 

--- a/docs/source/user/quickstart.rst
+++ b/docs/source/user/quickstart.rst
@@ -5,33 +5,29 @@ Quickstart tutorial
 Use edrixs as an ED calculator
 ------------------------------
 edrixs can be used as a simple ED calculator to get eigenvalues (eigenvectors) of a many-body Hamiltonian with small size dimension (:math:`< 1,000`).
-We will give an example to get eigenvalues for a :math:`p`-orbital system (:math:`l=1`). There are 6 orbitals including spin.
+We will give an example to get eigenvalues for a :math:`t_{2g}`-orbital system (:math:`l_{eff}=1`). There are 6 orbitals including spin.
 
 Launch your favorite python terminal::
     
     >>> import edrixs
-    >>> norb = 6    # number of orbitals
-    >>> U, J = 4.0, 1.0    # Coulomb U and Hund's coupling J
-    >>> mu = 5 * (U / 2 - J)    # chemical potential, particle-hole symmetry
-    >>> emat = - np.eye(norb) * mu
-    >>> umat = edrixs.get_umat_kanamori(norb, U, J)    # Kanamori type of Coulomb interaction
-    >>> eigval = []
-    >>> eigvec = []
-    >>> for noccu in range(norb+1):    # loop over all the possible occupancy
-    ...     basis = edrixs.get_fock_bin_by_N(norb, noccu)    # Fock basis
-    ...     H = edrixs.two_fermion(emat, basis, basis)    # Hamiltonian, two fermion terms
-    ...     H += edrixs.four_fermion(umat, basis)    # Hamiltonian, four fermion terms
-    ...     e, v = scipy.linalg.eigh(H)  # do ED
-    ...     print(noccu, e)
-    ...     eigval.append(e)
-    ...     eigvec.append(v)
-    0 [0.]
-    1 [-5. -5. -5. -5. -5. -5.]
-    2 [-9. -9. -9. -9. -9. -9. -9. -9. -9. -7. -7. -7. -7. -7. -4.]
-    3 [-12. -12. -12. -12.  -9.  -9.  -9.  -9.  -9.  -9.  -9.  -9.  -9.  -9.  -7.  -7.  -7.  -7.  -7.  -7.]
-    4 [-9. -9. -9. -9. -9. -9. -9. -9. -9. -7. -7. -7. -7. -7. -4.]
-    5 [-5. -5. -5. -5. -5. -5.]
-    6 [0.]
+    >>> import scipy
+    >>> norb = 6
+    >>> noccu = 2
+    >>> Ud, JH = edrixs.UJ_to_UdJH(4, 1)
+    >>> F0, F2, F4 = edrixs.UdJH_to_F0F2F4(Ud, JH)
+    >>> umat = edrixs.get_umat_slater('t2g', F0, F2, F4)
+    >>> emat = edrixs.atom_hsoc('t2g', 0.2)
+    >>> basis = edrixs.get_fock_bin_by_N(norb, noccu)
+    >>> H = edrixs.build_opers(4, umat, basis)
+    >>> e1, v1 = scipy.linalg.eigh(H)
+    >>> H += edrixs.build_opers(2, emat, basis)
+    >>> e2, v2 = scipy.linalg.eigh(H)
+    >>> print(e1)
+    [1. 1. 1. 1. 1. 1. 1. 1. 1. 3. 3. 3. 3. 3. 6.]
+    >>> print(e2)
+    [0.890519 0.890519 0.890519 0.890519 0.890519 1.1      1.1      1.1
+     1.183391 3.009481 3.009481 3.009481 3.009481 3.009481 6.016609]
+
 
 Hello RIXS!
 -----------

--- a/edrixs/angular_momentum.py
+++ b/edrixs/angular_momentum.py
@@ -202,11 +202,11 @@ def get_orb_momentum(l, ispin=False):
     res: 3d complex array
         The matrix form of
 
-        - res[0], :math:`l_x`
+        - res[0]: :math:`l_x`
 
-        - res[1], :math:`l_y`
+        - res[1]: :math:`l_y`
 
-        - res[2], :math:`l_z`
+        - res[2]: :math:`l_z`
 
         If ispin=True, the dimension will be :math:`3 \\times 2(2l+1) \\times 2(2l+1)`,
 
@@ -352,11 +352,11 @@ def get_spin_momentum(l):
     res: 3d complex array
         The matrix form of
 
-        - res[0], :math:`s_x`
+        - res[0]: :math:`s_x`
 
-        - res[1], :math:`s_y`
+        - res[1]: :math:`s_y`
 
-        - res[2], :math:`s_z`
+        - res[2]: :math:`s_z`
 
         the dimension is :math:`3 \\times 2(2l+1) \\times 2(2l+1)`,
 

--- a/edrixs/angular_momentum.py
+++ b/edrixs/angular_momentum.py
@@ -1,6 +1,6 @@
-__all__ = ['get_ladd', 'get_lminus', 'get_lx', 'get_ly', 'get_lz', 'get_pauli',
-           'get_sx', 'get_sy', 'get_sz', 'euler_to_rmat', 'rmat_to_euler',
-           'where_is_angle', 'dmat_spinor', 'zx_to_rmat', 'get_wigner_dmat',
+__all__ = ['get_ladd', 'get_lminus', 'get_lx', 'get_ly', 'get_lz', 'get_orb_momentum',
+           'get_pauli', 'get_sx', 'get_sy', 'get_sz', 'get_spin_momentum', 'euler_to_rmat',
+           'rmat_to_euler', 'where_is_angle', 'dmat_spinor', 'zx_to_rmat', 'get_wigner_dmat',
            'cf_cubic_d', 'cf_tetragonal_d', 'cf_trigonal_t2g']
 
 import numpy as np
@@ -185,6 +185,45 @@ def get_lz(l, ispin=False):
         return lz
 
 
+def get_orb_momentum(l, ispin=False):
+    """
+    Get the matrix form of the orbital angular momentum
+    operator :math:`l_x, l_y, l_z` in the complex spherical harmonics basis.
+
+    Parameters
+    ----------
+    l: int
+        Orbital angular momentum number.
+    ispin: logical
+        Whether including spin or not (default: False).
+
+    Returns
+    -------
+    res: 3d complex array
+        The matrix form of
+
+        - res[0], :math:`l_x`
+
+        - res[1], :math:`l_y`
+
+        - res[2], :math:`l_z`
+
+        If ispin=True, the dimension will be :math:`3 \\times 2(2l+1) \\times 2(2l+1)`,
+
+        otherwise, it will be :math:`3 \\times (2l+1) \\times (2l+1)`.
+    """
+    norbs = 2 * l + 1
+    if ispin:
+        res = np.zeros((3, 2*norbs, 2*norbs), dtype=np.complex128)
+    else:
+        res = np.zeros((3, norbs, norbs), dtype=np.complex128)
+    res[0] = get_lx(l, ispin)
+    res[1] = get_ly(l, ispin)
+    res[2] = get_lz(l, ispin)
+
+    return res
+
+
 def get_pauli():
     """
     Get the Pauli matrix
@@ -193,11 +232,11 @@ def get_pauli():
     -------
     sigma: 3d complex array, shape=(3, 2, 2)
 
-        sigma[0] is :math:`\\sigma_x`,
+        - sigma[0] is :math:`\\sigma_x`,
 
-        sigma[1] is :math:`\\sigma_y`,
+        - sigma[1] is :math:`\\sigma_y`,
 
-        sigma[2] is :math:`\\sigma_z`,
+        - sigma[2] is :math:`\\sigma_z`,
     """
 
     sigma = np.zeros((3, 2, 2), dtype=np.complex128)
@@ -296,6 +335,41 @@ def get_sz(l):
         sz[2 * i:2 * i + 2, 2 * i:2 * i + 2] = sigma[2, :, :] / 2.0
 
     return sz
+
+
+def get_spin_momentum(l):
+    """
+    Get the matrix form of the spin angular momentum
+    operator :math:`s_x, s_y, s_z` in the complex spherical harmonics basis.
+
+    Parameters
+    ----------
+    l: int
+        Orbital angular momentum number.
+
+    Returns
+    -------
+    res: 3d complex array
+        The matrix form of
+
+        - res[0], :math:`s_x`
+
+        - res[1], :math:`s_y`
+
+        - res[2], :math:`s_z`
+
+        the dimension is :math:`3 \\times 2(2l+1) \\times 2(2l+1)`,
+
+        Orbital order is: \\|-l,up\\>, \\|-l,down\\>, ...,
+        \\|+l, up\\>, \\|+l,down\\>
+    """
+    norbs = 2 * (2 * l + 1)
+    res = np.zeros((3, norbs, norbs), dtype=np.complex128)
+    res[0] = get_sx(l)
+    res[1] = get_sy(l)
+    res[2] = get_sz(l)
+
+    return res
 
 
 def euler_to_rmat(alpha, beta, gamma):

--- a/edrixs/basis_transform.py
+++ b/edrixs/basis_transform.py
@@ -21,7 +21,7 @@ def cb_op(oper_O, TL, TR=None):
 
         - oper_O.shape = (3, 10, 10), means 3 operatos with dimension :math:`10 \\times 10`
 
-        - oper_O.shape = (2, 3, 10, 10), means :math:`2 \\time 3=6` operators with
+        - oper_O.shape = (2, 3, 10, 10), means :math:`2 \\times 3=6` operators with
           dimension :math:`10 \\times 10`
     TL: 2d array
         The unitary transformation matrix from basis :math:`A` to
@@ -78,7 +78,7 @@ def cb_op2(oper_O, TL, TR):
 
         - oper_O.shape = (3, 10, 10), means 3 operatos with dimension :math:`10 \\times 10`
 
-        - oper_O.shape = (2, 3, 10, 10), means :math:`2 \\time 3=6` operators with
+        - oper_O.shape = (2, 3, 10, 10), means :math:`2 \\times 3=6` operators with
           dimension :math:`10 \\times 10`
     TL: 2d array
         The unitary transformation matrix applied on the left.

--- a/edrixs/basis_transform.py
+++ b/edrixs/basis_transform.py
@@ -4,13 +4,13 @@ __all__ = ['cb_op', 'cb_op2', 'tmat_c2r', 'tmat_r2c', 'tmat_r2cub_f',
 import numpy as np
 
 
-def cb_op(oper_O, tmat_L, tmat_R=None):
+def cb_op(oper_O, TL, TR=None):
     """
     Change the basis of an operator :math:`\\hat{O}`.
 
     .. math::
 
-        O^{\\prime} = (tmat_L)^{\\dagger} O (tmat_R),
+        O^{\\prime} = (T_L)^{\\dagger} O (T_R),
 
     Parameters
     ----------
@@ -23,36 +23,38 @@ def cb_op(oper_O, tmat_L, tmat_R=None):
 
         - oper_O.shape = (2, 3, 10, 10), means :math:`2 \\time 3=6` operators with
           dimension :math:`10 \\times 10`
-    tmat_L: 2d array
+    TL: 2d array
         The unitary transformation matrix from basis :math:`A` to
         basis :math:`B`,  namely,
-        :math:`tmat_L_{ij} = <\\psi^{A}_{i}|\\phi^{B}_{j}>`.
 
-    tmat_R: 2d array
+        :math:`TL_{ij} = <\\psi^{A}_{i}|\\phi^{B}_{j}>`.
+
+    TR: 2d array
         The unitary transformation matrix from basis :math:`A` to
         basis :math:`B`,  namely,
-        :math:`tmat_R_{ij} = <\\psi^{A}_{i}|\\phi^{B}_{j}>`.
 
-        if tmat_R = None, tmat_R = tmat_L
+        :math:`TR_{ij} = <\\psi^{A}_{i}|\\phi^{B}_{j}>`.
+
+        if TR = None, TR = TL
 
     Returns
     -------
-    res : same shape as oper_O
+    res: same shape as oper_O
         The matrices form of operators :math:`\\hat{O}` in new basis.
     """
     oper_O = np.array(oper_O, order='C')
     dim = oper_O.shape
-    if tmat_R is None:
-        tmat_R = tmat_L
+    if TR is None:
+        TR = TL
     if len(dim) < 2:
         raise Exception("Dimension of oper_O should be at least 2")
     elif len(dim) == 2:
-        res = np.dot(np.dot(np.conj(np.transpose(tmat_L)), oper_O), tmat_R)
+        res = np.dot(np.dot(np.conj(np.transpose(TL)), oper_O), TR)
     else:
         tot = np.prod(dim[0:-2])
         tmp_oper = oper_O.reshape((tot, dim[-2], dim[-1]))
         for i in range(tot):
-            tmp_oper[i] = np.dot(np.dot(np.conj(np.transpose(tmat_L)), tmp_oper[i]), tmat_R)
+            tmp_oper[i] = np.dot(np.dot(np.conj(np.transpose(TL)), tmp_oper[i]), TR)
         res = tmp_oper.reshape(dim)
 
     return res
@@ -64,7 +66,7 @@ def cb_op2(oper_O, TL, TR):
 
     .. math::
 
-        O^{\\prime} = (TL)^{\\dagger} O (TR),
+        O^{\\prime} = (T_L)^{\\dagger} O (T_R),
 
 
     Parameters
@@ -85,7 +87,7 @@ def cb_op2(oper_O, TL, TR):
 
     Returns
     -------
-    res : same shape as oper_O
+    res: same shape as oper_O
         The matrices form of operators :math:`\\hat{O}` in new basis.
     """
     oper_O = np.array(oper_O, order='C')

--- a/edrixs/manybody_operator.py
+++ b/edrixs/manybody_operator.py
@@ -111,7 +111,8 @@ def four_fermion(umat, lb, rb=None, tol=1E-10):
 
     .. math::
 
-        <F_l|\\sum_{ij}U_{ijkl}\\hat{f}_{i}^{\\dagger}\\hat{f}_{j}^{\\dagger}\\hat{f}_{k}\\hat{f}_{l}|F_r>
+        <F_l|\\sum_{ij}U_{ijkl}\\hat{f}_{i}^{\\dagger}\\hat{f}_{j}^{\\dagger}
+        \\hat{f}_{k}\\hat{f}_{l}|F_r>
 
     Parameters
     ----------
@@ -171,6 +172,101 @@ def four_fermion(umat, lb, rb=None, tol=1E-10):
             jcfg = indx[tuple(tmp_basis)]
             if jcfg != -1:
                 hmat[jcfg, icfg] += umat[lorb, korb, jorb, iorb] * s1 * s2 * s3 * s4
+    return hmat
+
+
+def build_opers(nfermion, coeff, lb, rb=None, tol=1E-10):
+    """
+    Build matrix form of many-body operators in the given Fock basis,
+
+    .. math::
+
+        <F_{l}|\\sum_{ij}E_{ij}\\hat{f}_{i}^{\\dagger}\\hat{f}_{j}|F_{r}>
+
+    or
+
+    .. math::
+
+        <F_l|\\sum_{ij}U_{ijkl}\\hat{f}_{i}^{\\dagger}\\hat{f}_{j}^{\\dagger}
+        \\hat{f}_{k}\\hat{f}_{l}|F_r>
+
+    Parameters
+    ----------
+    nfermion: int
+        Number of fermion operators. Options can only be 2 or 4 now.
+    coeff: array-like
+        The coefficients.
+
+        - if nfermion=2, coeff should be at least 2-dimension, and the last 2-dimension is
+          the matrix of coefficients of an operator. For examples,
+
+          - coeff.shape = (3, 10, 10), means 3 operators with :math:`10 \\times 10`
+            coefficients matrix.
+
+          - coeff.shape = (2, 3, 10, 10), means :math:`2 \\times 3=6` operators with
+            :math:`10 \\times 10` coefficients matrix.
+
+        - if nfermion=4, coeff should be at least 4-dimension, and the last 4-dimension is
+          the rank-4 tensor of coefficients of an operator. For examples,
+
+          - coeff.shape = (3, 10, 10, 10, 10), means 3 operators with
+            :math:`10 \\times 10 \\times 10 \\times 10` coefficients tensor.
+
+          - coeff.shape = (2, 3, 10, 10, 10, 10), means :math:`2 \\times 3=6` operators with
+            :math:`10 \\times 10 \\times 10 \\times 10` coefficients tensor.
+    lb: list or array
+        Left fock basis :math:`<F_{l}|`.
+    rb: list of array
+        Right fock basis :math:`|F_{r}>`.
+        rb = lb if rb is None
+    tol: float (default: 1E-10)
+        Only consider the elements of emat that are larger than tol.
+
+    Returns
+    -------
+    hmat: array-like
+        At least 2-dimension and the last 2-dimension is matrix form of operators,
+        For examples,
+
+        - if nfermion=2, coeff.shape=(2, 3, 10, 10), hmat.shape=(2, 3, len(lb), len(rb))
+
+        - if nfermion=4, coeff.shape=(2, 3, 10, 10, 10, 10), hmat.shape=(2, 3, len(lb), len(rb))
+    """
+    if nfermion not in [2, 4]:
+        raise Exception("nfermion is not 2 or 4")
+    nl = len(lb)
+    if rb is None:
+        nr = nl
+    else:
+        nr = len(rb)
+    coeff = np.array(coeff, order='C')
+    if nfermion == 2:
+        dim = coeff.shape
+        if len(dim) < 2:
+            raise Exception("Dimension of coeff should be at least 2 when nfermion=2")
+        elif len(dim) == 2:
+            hmat = two_fermion(coeff, lb, rb, tol)
+        else:
+            tot = np.prod(dim[0:-2])
+            hmat_tmp = np.zeros((tot, nl, nr), dtype=np.complex)
+            coeff_tmp = coeff.reshape((tot, dim[-2], dim[-1]))
+            for i in range(tot):
+                hmat_tmp[i] = two_fermion(coeff_tmp[i], lb, rb, tol)
+            hmat = hmat_tmp.reshape((dim[0:-2], nl, nr))
+    if nfermion == 4:
+        dim = coeff.shape
+        if len(dim) < 4:
+            raise Exception("Dimension of coeff should be at least 4 when nfermion=4")
+        elif len(dim) == 4:
+            hmat = four_fermion(coeff, lb, rb, tol)
+        else:
+            tot = np.prod(dim[0:-4])
+            hmat_tmp = np.zeros((tot, nl, nr), dtype=np.complex)
+            coeff_tmp = coeff.reshape((tot, dim[-4], dim[-3], dim[-2], dim[-1]))
+            for i in range(tot):
+                hmat_tmp[i] = four_fermion(coeff_tmp[i], lb, rb, tol)
+            hmat = hmat_tmp.reshape((dim[0:-2], nl, nr))
+
     return hmat
 
 

--- a/edrixs/manybody_operator.py
+++ b/edrixs/manybody_operator.py
@@ -1,4 +1,5 @@
-__all__ = ['one_fermion_annihilation', 'two_fermion', 'four_fermion', 'density_matrix']
+__all__ = ['one_fermion_annihilation', 'two_fermion', 'four_fermion',
+           'build_opers', 'density_matrix']
 
 import numpy as np
 from collections import defaultdict
@@ -60,7 +61,7 @@ def two_fermion(emat, lb, rb=None, tol=1E-10):
     ----------
     emat: 2d complex array
         The impurity matrix.
-    lb: list or array
+    lb: list of array
         Left fock basis :math:`<F_{l}|`.
     rb: list of array
         Right fock basis :math:`|F_{r}>`.
@@ -118,7 +119,7 @@ def four_fermion(umat, lb, rb=None, tol=1E-10):
     ----------
     umat: 4d complex array
         The 4 index Coulomb interaction tensor.
-    lb: list or array
+    lb: list of array
         Left fock basis :math:`<F_{l}|`.
     rb: list of array
         Right fock basis :math:`|F_{r}>`.
@@ -214,7 +215,7 @@ def build_opers(nfermion, coeff, lb, rb=None, tol=1E-10):
 
           - coeff.shape = (2, 3, 10, 10, 10, 10), means :math:`2 \\times 3=6` operators with
             :math:`10 \\times 10 \\times 10 \\times 10` coefficients tensor.
-    lb: list or array
+    lb: list of array
         Left fock basis :math:`<F_{l}|`.
     rb: list of array
         Right fock basis :math:`|F_{r}>`.
@@ -265,7 +266,7 @@ def build_opers(nfermion, coeff, lb, rb=None, tol=1E-10):
             coeff_tmp = coeff.reshape((tot, dim[-4], dim[-3], dim[-2], dim[-1]))
             for i in range(tot):
                 hmat_tmp[i] = four_fermion(coeff_tmp[i], lb, rb, tol)
-            hmat = hmat_tmp.reshape((dim[0:-2], nl, nr))
+            hmat = hmat_tmp.reshape((dim[0:-4], nl, nr))
 
     return hmat
 

--- a/edrixs/manybody_operator.py
+++ b/edrixs/manybody_operator.py
@@ -253,7 +253,7 @@ def build_opers(nfermion, coeff, lb, rb=None, tol=1E-10):
             coeff_tmp = coeff.reshape((tot, dim[-2], dim[-1]))
             for i in range(tot):
                 hmat_tmp[i] = two_fermion(coeff_tmp[i], lb, rb, tol)
-            hmat = hmat_tmp.reshape((dim[0:-2], nl, nr))
+            hmat = hmat_tmp.reshape(dim[0:-2] + (nl, nr))
     if nfermion == 4:
         dim = coeff.shape
         if len(dim) < 4:
@@ -266,7 +266,7 @@ def build_opers(nfermion, coeff, lb, rb=None, tol=1E-10):
             coeff_tmp = coeff.reshape((tot, dim[-4], dim[-3], dim[-2], dim[-1]))
             for i in range(tot):
                 hmat_tmp[i] = four_fermion(coeff_tmp[i], lb, rb, tol)
-            hmat = hmat_tmp.reshape((dim[0:-4], nl, nr))
+            hmat = hmat_tmp.reshape(dim[0:-4] + (nl, nr))
 
     return hmat
 

--- a/edrixs/manybody_operator.py
+++ b/edrixs/manybody_operator.py
@@ -48,7 +48,7 @@ def one_fermion_annihilation(iorb, lb, rb):
     return hmat
 
 
-def two_fermion(emat, lb, rb, tol=1E-10):
+def two_fermion(emat, lb, rb=None, tol=1E-10):
     """
     Build matrix form of a two-fermionic operator in the given Fock basis,
 
@@ -64,6 +64,7 @@ def two_fermion(emat, lb, rb, tol=1E-10):
         Left fock basis :math:`<F_{l}|`.
     rb: list of array
         Right fock basis :math:`|F_{r}>`.
+        rb = lb if rb is None
     tol: float (default: 1E-10)
         Only consider the elements of emat that are larger than tol.
 
@@ -72,7 +73,8 @@ def two_fermion(emat, lb, rb, tol=1E-10):
     hmat: 2d complex array
         The matrix form of the two-fermionic operator.
     """
-
+    if rb is None:
+        rb = lb
     lb, rb = np.array(lb), np.array(rb)
     nr, nl, norbs = len(rb), len(lb), len(rb[0])
     indx = defaultdict(lambda: -1)
@@ -103,20 +105,23 @@ def two_fermion(emat, lb, rb, tol=1E-10):
     return hmat
 
 
-def four_fermion(umat, basis, tol=1E-10):
+def four_fermion(umat, lb, rb=None, tol=1E-10):
     """
     Build matrix form of a four-fermionic operator in the given Fock basis,
 
     .. math::
 
-        <F|\\sum_{ij}U_{ijkl}\\hat{f}_{i}^{\\dagger}\\hat{f}_{j}^{\\dagger}\\hat{f}_{k}\\hat{f}_{l}|F>
+        <F_l|\\sum_{ij}U_{ijkl}\\hat{f}_{i}^{\\dagger}\\hat{f}_{j}^{\\dagger}\\hat{f}_{k}\\hat{f}_{l}|F_r>
 
     Parameters
     ----------
     umat: 4d complex array
         The 4 index Coulomb interaction tensor.
-    basis: list or array
-        Fock basis :math:`|F>`.
+    lb: list or array
+        Left fock basis :math:`<F_{l}|`.
+    rb: list of array
+        Right fock basis :math:`|F_{r}>`.
+        rb = lb if rb is None
     tol: float (default: 1E-10)
         Only consider the elements of umat that are larger than tol.
 
@@ -125,23 +130,24 @@ def four_fermion(umat, basis, tol=1E-10):
     hmat: 2d complex array
         The matrix form of the four-fermionic operator.
     """
-
-    basis = np.array(basis)
-    ncfgs, norbs = len(basis), len(basis[0])
+    if rb is None:
+        rb = lb
+    lb, rb = np.array(lb), np.array(rb)
+    nr, nl, norbs = len(rb), len(lb), len(rb[0])
     indx = defaultdict(lambda: -1)
-    for i, j in enumerate(basis):
+    for i, j in enumerate(lb):
         indx[tuple(j)] = i
 
     a1, a2, a3, a4 = np.nonzero(abs(umat) > tol)
     nonzero = np.stack((a1, a2, a3, a4), axis=-1)
 
-    hmat = np.zeros((ncfgs, ncfgs), dtype=np.complex128)
+    hmat = np.zeros((nl, nr), dtype=np.complex128)
     tmp_basis = np.zeros(norbs)
     for lorb, korb, jorb, iorb in nonzero:
         if iorb == jorb or korb == lorb:
             continue
-        for icfg in range(ncfgs):
-            tmp_basis[:] = basis[icfg]
+        for icfg in range(nr):
+            tmp_basis[:] = rb[icfg]
             if tmp_basis[iorb] == 0:
                 continue
             else:


### PR DESCRIPTION
Several python APIs are simplified and more powerful. Major changes are:

1. add `get_orb_momentum` and `get_spin_momentum` to return `lx, ly, lz` or `sx, sy, sz` in a 3d-array.

2. change `cb_op` and `cb_op2` to do the transformation for many operators (same size) in one call, for example,

`op1_new, op2_new = cb_op([op1, op2], tmat)` or
`op_new =cb_op([[op1, op2], [op3, op4]], tmat)`
`op_new.shape == (2, 2) + op1.shape` or more complex array or list of operators

3. add new general function `build_opers` to build many body Hamiltonian for two or four fermion cases. It can also build many operators (same size) in one call, for example,

`op1, op2 = build_opers(2, [emat1, emat2], basis)  # for two-fermion`
`op3, op4 = build_opers(4, [umat1, umat2], basis)  # for four-fermion`
