### PR TITLE
adjust base image of Dockerfile_interactive

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ edrixs
 
 
 An open source toolkit for simulating RIXS spectra based on exact diagonalization (ED) for strongly correlated materials.
-It is developed as part of `COMSCOPE project <https://www.bnl.gov/comscope/software/comsuite.php/>`_ in the Center for Computational Material Spectroscopy and Design, Brookhaven National Laboratory
+`It is developed <https://www.bnl.gov/comscope/software/EDRIXS.php>`_ as part of `COMSCOPE project <https://www.bnl.gov/comscope/software/comsuite.php/>`_ in the Center for Computational Material Spectroscopy and Design, Brookhaven National Laboratory
 
 * Free software: GNU General Public License Version 3
 * Documentation: https://nsls-ii.github.io/edrixs.

--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ Follow these steps to use the docker image:
        $ docker pull edrixs/edrixs    # pull latest version
        $ docker run -it -p 8888:8888 -u rixs -w /home/rixs -v /dir/on/your/host/os:/home/rixs/data edrixs/edrixs
        
-  it will take a while to pull the image from `Docker Hub <https://cloud.docker.com/repository/docker/laowang2017/edrixs/>`_ for the first time, while, it will launch the local one very fast at the next time.
+  it will take a while to pull the image from `Docker Hub <https://cloud.docker.com/repository/docker/edrixs/edrixs/>`_ for the first time, while, it will launch the local one very fast at the next time.
   
   * ``-p 8888:8888`` maps container's port 8888 to host port 8888.
   * ``-u rix`` means using a default user ``rixs`` to login the Ubuntu Linux, the password is ``rixs``. 

--- a/docker/Dockerfile_interactive
+++ b/docker/Dockerfile_interactive
@@ -1,4 +1,4 @@
-FROM edrixs/edrixs
+FROM edrixs/edrixs_base
 WORKDIR /project
 
 RUN apt-get update \
@@ -8,3 +8,21 @@ RUN apt-get update \
     && pip install ipympl \
     && jupyter labextension install @jupyter-widgets/jupyterlab-manager \
     && jupyter labextension install jupyter-matplotlib \
+
+COPY . ./src/edrixs
+
+    # build fortran part of edrixs
+RUN export LD_LIBRARY_PATH="/usr/local/lib:\$LD_LIBRARY_PATH" \
+    && make -C src/edrixs/src F90=mpif90 LIBS="-L/usr/local/lib -lopenblas -lparpack -larpack" \
+    && make install -C src/edrixs/src \
+    # build python part of edrixs
+    && cd src/edrixs \
+    && python setup.py build_ext --library-dirs=/usr/local/lib \
+    && pip install . \
+    && cd ../../  \
+    # set env
+    && echo "export PATH=/project/src/edrixs/bin:\$PATH" >> ~/.bashrc  \
+    && echo "export PATH=/project/src/edrixs/bin:\$PATH" >> /home/rixs/.bashrc  \
+    # copy examples to /home/rixs
+    && cp -r src/edrixs/examples /home/rixs/edrixs_examples \
+    && chown -R rixs:rixs /home/rixs/edrixs_examples \

--- a/docs/source/user/usedocker.rst
+++ b/docs/source/user/usedocker.rst
@@ -17,7 +17,7 @@ Follow these steps to use the docker image:
     $ docker pull edrixs/edrixs    # pull latest version
     $ docker run -it -u rixs -w /home/rixs -v /dir/on/your/host/os:/home/rixs/data edrixs/edrixs
 
-  it will take a while to pull the image from `Docker Hub <https://cloud.docker.com/repository/docker/laowang2017/edrixs/>`_ for the first time, while, it will launch the local one very fast at the next time.
+  it will take a while to pull the image from `Docker Hub <https://cloud.docker.com/repository/docker/edrixs/edrixs/>`_ for the first time, while, it will launch the local one very fast at the next time.
 
   * ``-u rixs`` means using a default user ``rixs`` to login the Ubuntu Linux, the password is ``rixs``.
 


### PR DESCRIPTION
I found that it is better to set the base image of  docker_interactive as edrixs_base instead of edrixs, otherwise, docker_interactive will install those deps every time when edrixs source is updated.