### PR TITLE
Update setup.py to fix the issue that f2py doesn't set '-shared' link option in some linux system

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include README.rst
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 
+recursive-include src *.f90 make.* Makefile
 recursive-include docs *.rst conf.py Makefile make.bat
 
 include versioneer.py

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ with open(path.join(here, 'requirements.txt')) as requirements_file:
 
 # Python interface to call fortran subroutines
 if 'linux' in sys.platform:
-    extra_link_args=['-shared']
+    extra_link_args = ['-shared']
 else:
     extra_link_args=[]
 ext_fortran = Extension(name='edrixs.fedrixs',

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,13 @@ with open(path.join(here, 'requirements.txt')) as requirements_file:
                     if not line.startswith('#')]
 
 # Python interface to call fortran subroutines
+if 'linux' in sys.platform:
+    extra_link_args=['-shared']
+else:
+    extra_link_args=[]
 ext_fortran = Extension(name='edrixs.fedrixs',
-                        sources=['src/pyapi.f90'])
+                        sources=['src/pyapi.f90'],
+                        extra_link_args=extra_link_args)
 
 setup(
     name='edrixs',

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ with open(path.join(here, 'requirements.txt')) as requirements_file:
 if 'linux' in sys.platform:
     extra_link_args = ['-shared']
 else:
-    extra_link_args=[]
+    extra_link_args = []
 ext_fortran = Extension(name='edrixs.fedrixs',
                         sources=['src/pyapi.f90'],
                         extra_link_args=extra_link_args)


### PR DESCRIPTION
The error "start.S:99: undefined reference to `main'"  from building fortran extension in [docker nsls2/debian-with-miniconda](https://hub.docker.com/r/nsls2/debian-with-miniconda/tags/) is due to that f2py doesn't set '-shared' link option in the link stage, so I update the setup.py to explicitly set that option when the system is Linux. 

MANIFEST.in file is also updated to include src/* in distribution package.