### PR TITLE
Change to docker interactive

### DIFF
--- a/docker/Dockerfile_interactive
+++ b/docker/Dockerfile_interactive
@@ -1,15 +1,20 @@
 FROM edrixs/edrixs_base
 WORKDIR /project
 
-RUN apt-get update \
-    && apt-get install -y curl \
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
+    && apt-get update \
+    && apt-get install -y -q --no-install-recommends curl \
     && curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash - \
+    && apt install -y git \
     && apt install -y nodejs \
     && pip install ipympl \
     && jupyter labextension install @jupyter-widgets/jupyterlab-manager \
-    && jupyter labextension install jupyter-matplotlib 
+    && jupyter labextension install jupyter-matplotlib
 
-COPY . ./src/edrixs
+    # Get edrixs
+RUN git clone https://github.com/NSLS-II/edrixs.git \
+    && mkdir src \
+    && cp -r edrixs src/
 
     # build fortran part of edrixs
 RUN export LD_LIBRARY_PATH="/usr/local/lib:\$LD_LIBRARY_PATH" \
@@ -26,3 +31,5 @@ RUN export LD_LIBRARY_PATH="/usr/local/lib:\$LD_LIBRARY_PATH" \
     # copy examples to /home/rixs
     && cp -r src/edrixs/examples /home/rixs/edrixs_examples \
     && chown -R rixs:rixs /home/rixs/edrixs_examples
+
+CMD jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --allow-root

--- a/docs/source/user/usedocker.rst
+++ b/docs/source/user/usedocker.rst
@@ -49,10 +49,10 @@ Connect to docker python session with Jupyter
 
 * To use this follow the steps above, but pass an additional command ``-p 8888`` when you launch the container i.e.::
 
-    $ docker run -it -p 8888:8888 -u rixs -w /home/rixs -v /dir/on/your/host/os:/home/rixs/data edrixs/edrixs
+    $ docker run -it -p 8888:8888 -u rixs -w /home/rixs -v /dir/on/your/host/os:/home/rixs/data edrixs/edrixs_interactive
 
-  from within the container initiate the jupyter session as::
+the container will automatically launch a jupyter session as::
 
     $ jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --allow-root
 
-  This will return a URL that you can enter in a browser on your host machine. If you want to use interactive `ipython widgets <https://ipywidgets.readthedocs.io/en/stable/>`_ and `plotting <https://github.com/matplotlib/jupyter-matplotlib>`_, replace ``edrixs/edrixs`` with ``edrixs/edrixs_interactive``. This downloads a (larger) container with the required additional packages.
+  and will return a URL that you can enter in a browser on your host machine. The larger ``edrixs/edrixs_interactive'' container includes [ipywidgets](https://ipywidgets.readthedocs.io/en/latest/) and [ipympl](https://github.com/matplotlib/jupyter-matplotlib) for interactive computing.


### PR DESCRIPTION
Since our docker image edrixs/edrixs_interactive is designed for use with jupyter I decided to add the command to launch the jupyterlab by default as the comand is quite cumbersome.

I had significant trouble building the docker images, however. I experience two problems:
1. I got an error
" There are services installed on your system which need to be restarted"
this is why I'm suggesting the change at line 4 of the Dockerfile_interactive.
2. The edrixs source code did not appear to exist in the container? 