### PR TITLE
add instructions for python usage

### DIFF
--- a/docs/source/user/index.rst
+++ b/docs/source/user/index.rst
@@ -15,3 +15,4 @@ edrixs User Guide
    usedocker
    quickstart
    basics
+   pythontips

--- a/docs/source/user/pythontips.rst
+++ b/docs/source/user/pythontips.rst
@@ -45,7 +45,7 @@ A brute force option to look at a variable deep within the code is to use a debu
      python3 -m pdb myscript.py
 
 Use ``import pdb; pdb.set_trace()`` to set the place where you want to enter the
-debugger. See `here <docs.python.org/3/library/pdb.html>`_ for more details.
+debugger. See `here <https://docs.python.org/3/library/pdb.html>`_ for more details.
 
 If you are feeling even braver, you can browse the Fortran code which does the
 heavyweight computation. Either in the source edrixs directory or via the online

--- a/docs/source/user/pythontips.rst
+++ b/docs/source/user/pythontips.rst
@@ -38,6 +38,15 @@ and the object code respectively.::
 Including ``%matplotlib widget`` in your script
 will facilitate interactive plots. All these interactive options are also available
 in the rich outputs possible within the
-`juptyer lab <https://jupyterlab.readthedocs.io/en/stable/>`_ interface. If you are feeling even braver, you can browse the Fortran code which does the
+`juptyer lab <https://jupyterlab.readthedocs.io/en/stable/>`_ interface.
+
+A brute force option to look at a variable deep within the code is to use a debugger::
+
+     python3 -m pdb myscript.py
+
+Use ``import pdb; pdb.set_trace()`` to set the place where you want to enter the
+debugger. See `here <docs.python.org/3/library/pdb.html>`_ for more details.
+
+If you are feeling even braver, you can browse the Fortran code which does the
 heavyweight computation. Either in the source edrixs directory or via the online
 `edrixs repo <http://www.github.com/NSLS-II/edrixs>`_.

--- a/docs/source/user/pythontips.rst
+++ b/docs/source/user/pythontips.rst
@@ -1,0 +1,43 @@
+.. _pythontips:
+
+**************************
+Tips for python and edrixs
+**************************
+
+In the design of edrixs, we made a deliberate choice to use
+`python <http://www.python.org>`_ for the application programming interface. This is
+because of its readability, easy of use and flexibility to run and combine it
+in many different ways.
+
+The standard way to run a python script ``myscript.py`` is::
+
+     python myscript.py
+
+This will generate the outputs of the script such as plots you choose to save
+and print statements will be returned into the terminal. You can save the print
+output by simply redirecting the output to a file::
+
+     python myscript.py > myoutput.txt
+
+For more exploratory usage,  `IPython <http://ipython.org>`_ or
+`Jupyter <http://www.jupyter.org>`_
+can be very useful. (See :ref:`edrixsanddocker` for invoking jupyter over docker.)
+After starting IPython by typing ``ipython`` at the command line
+you might find it useful to execute your script via::
+
+     %run -i myscript.py
+
+The *interactive* flag ``-i`` means that all the variables and functions you loaded
+will be available to you at the command line. These can be straightforwardly printed
+or inspected via the ``?`` or ``??`` flags, which show you the object documentation
+and the object code respectively.::
+
+     from edrixs import cd_cubic_d
+     cd_cubic_d??
+
+Including ``%matplotlib widget`` in your script
+will facilitate interactive plots. All these interactive options are also available
+in the rich outputs possible within the
+`juptyer lab <https://jupyterlab.readthedocs.io/en/stable/>`_ interface. If you are feeling even braver, you can browse the Fortran code which does the
+heavyweight computation. Either in the source edrixs directory or via the online
+`edrixs repo <http://www.github.com/NSLS-II/edrixs>`_.


### PR DESCRIPTION
This is extra documentation (written in response to the conversation with the Yale folks). I think they are finding it hard to inspect the output in detail. Especially if they are adding print statements in the source code. 