### PR TITLE
remove ambiguous variable name 'l'

### DIFF
--- a/edrixs/angular_momentum.py
+++ b/edrixs/angular_momentum.py
@@ -7,18 +7,18 @@ import numpy as np
 from .basis_transform import cb_op, tmat_r2c
 
 
-def get_ladd(l, ispin=False):
+def get_ladd(ll, ispin=False):
     """
     Get the matrix form of the raising operator :math:`l^+` in the
     complex spherical harmonics basis
 
     .. math::
 
-        l^+|l,m> = \\sqrt{(l-m)(l+m+1)} |l,m+1>
+        l^+|ll,m> = \\sqrt{(ll-m)(ll+m+1)} |ll,m+1>
 
     Parameters
     ----------
-    l: int
+    ll: int
         Orbital angular momentum number.
     ispin: logical
         Whether including spin or not (default: False).
@@ -28,16 +28,16 @@ def get_ladd(l, ispin=False):
     ladd: 2d complex array
         The matrix form of :math:`l^+`.
 
-        If ispin=True, the dimension will be :math:`2(2l+1) \\times 2(2l+1)`,
+        If ispin=True, the dimension will be :math:`2(2ll+1) \\times 2(2ll+1)`,
 
-        otherwise, it will be :math:`(2l+1) \\times (2l+1)`.
+        otherwise, it will be :math:`(2ll+1) \\times (2ll+1)`.
     """
 
-    norbs = 2 * l + 1
+    norbs = 2 * ll + 1
     ladd = np.zeros((norbs, norbs), dtype=np.complex128)
     cone = np.complex128(1.0 + 0.0j)
-    for m in range(-l, l):
-        ladd[l + m + 1, l + m] = np.sqrt((l - m) * (l + m + 1.0) * cone)
+    for m in range(-ll, ll):
+        ladd[ll + m + 1, ll + m] = np.sqrt((ll - m) * (ll + m + 1.0) * cone)
     if ispin:
         ladd_spin = np.zeros((2 * norbs, 2 * norbs), dtype=np.complex128)
         ladd_spin[0:2 * norbs:2, 0:2 * norbs:2] = ladd
@@ -47,18 +47,18 @@ def get_ladd(l, ispin=False):
         return ladd
 
 
-def get_lminus(l, ispin=False):
+def get_lminus(ll, ispin=False):
     """
     Get the matrix form of the lowering operator :math:`l^-` in the
     complex spherical harmonics basis
 
     .. math::
 
-        l^-|l,m> = \\sqrt{(l+m)(l-m+1)} |l,m-1>
+        l^-|ll,m> = \\sqrt{(ll+m)(ll-m+1)} |ll,m-1>
 
     Parameters
     ----------
-    l: int
+    ll: int
         Orbital angular momentum number.
     ispin: logical
         Whether including spin or not (default: False).
@@ -68,16 +68,16 @@ def get_lminus(l, ispin=False):
     lminus: 2d complex array
         The matrix form of :math:`l^-`.
 
-        If ispin=True, the dimension will be :math:`2(2l+1) \\times 2(2l+1)`,
+        If ispin=True, the dimension will be :math:`2(2ll+1) \\times 2(2ll+1)`,
 
-        otherwise, it will be :math:`(2l+1) \\times (2l+1)`.
+        otherwise, it will be :math:`(2ll+1) \\times (2ll+1)`.
     """
 
-    norbs = 2 * l + 1
+    norbs = 2 * ll + 1
     lminus = np.zeros((norbs, norbs), dtype=np.complex128)
     cone = np.complex128(1.0 + 0.0j)
-    for m in range(-l + 1, l + 1):
-        lminus[l + m - 1, l + m] = np.sqrt((l + m) * (l - m + 1.0) * cone)
+    for m in range(-ll + 1, ll + 1):
+        lminus[ll + m - 1, ll + m] = np.sqrt((ll + m) * (ll - m + 1.0) * cone)
     if ispin:
         lminus_spin = np.zeros((2 * norbs, 2 * norbs), dtype=np.complex128)
         lminus_spin[0:2 * norbs:2, 0:2 * norbs:2] = lminus
@@ -87,7 +87,7 @@ def get_lminus(l, ispin=False):
         return lminus
 
 
-def get_lx(l, ispin=False):
+def get_lx(ll, ispin=False):
     """
     Get the matrix form of the orbital angular momentum
     operator :math:`l_x` in the complex spherical harmonics basis,
@@ -98,7 +98,7 @@ def get_lx(l, ispin=False):
 
     Parameters
     ----------
-    l: int
+    ll: int
         Orbital angular momentum number.
     ispin: logical
         Whether including spin or not (default: False).
@@ -108,18 +108,18 @@ def get_lx(l, ispin=False):
     lx: 2d complex array
         The matrix form of :math:`l_x`.
 
-        If ispin=True, the dimension will be :math:`2(2l+1) \\times 2(2l+1)`,
+        If ispin=True, the dimension will be :math:`2(2ll+1) \\times 2(2ll+1)`,
 
-        otherwise, it will be :math:`(2l+1) \\times (2l+1)`.
+        otherwise, it will be :math:`(2ll+1) \\times (2ll+1)`.
     """
 
     if ispin:
-        return (get_ladd(l, True) + get_lminus(l, True)) / 2.0
+        return (get_ladd(ll, True) + get_lminus(ll, True)) / 2.0
     else:
-        return (get_ladd(l) + get_lminus(l)) / 2.0
+        return (get_ladd(ll) + get_lminus(ll)) / 2.0
 
 
-def get_ly(l, ispin=False):
+def get_ly(ll, ispin=False):
     """
     Get the matrix form of the orbital angular momentum
     operator :math:`l_y` in the complex spherical harmonics basis,
@@ -130,7 +130,7 @@ def get_ly(l, ispin=False):
 
     Parameters
     ----------
-    l: int
+    ll: int
         Orbital angular momentum number.
     ispin: logical
         Whether including spin or not (default: False).
@@ -140,25 +140,25 @@ def get_ly(l, ispin=False):
     ly: 2d complex array
         The matrix form of :math:`l_y`.
 
-        If ispin=True, the dimension will be :math:`2(2l+1) \\times 2(2l+1)`,
+        If ispin=True, the dimension will be :math:`2(2ll+1) \\times 2(2ll+1)`,
 
-        otherwise, it will be :math:`(2l+1) \\times (2l+1)`.
+        otherwise, it will be :math:`(2ll+1) \\times (2ll+1)`.
     """
 
     if ispin:
-        return (get_ladd(l, True) - get_lminus(l, True)) / 2.0 * -1j
+        return (get_ladd(ll, True) - get_lminus(ll, True)) / 2.0 * -1j
     else:
-        return (get_ladd(l) - get_lminus(l)) / 2.0 * -1j
+        return (get_ladd(ll) - get_lminus(ll)) / 2.0 * -1j
 
 
-def get_lz(l, ispin=False):
+def get_lz(ll, ispin=False):
     """
     Get the matrix form of the orbital angular momentum
     operator :math:`l_z` in the complex spherical harmonics basis.
 
     Parameters
     ----------
-    l: int
+    ll: int
         Orbital angular momentum number.
     ispin: logical
         Whether including spin or not (default: False).
@@ -168,14 +168,14 @@ def get_lz(l, ispin=False):
     lz: 2d complex array
         The matrix form of :math:`l_z`.
 
-        If ispin=True, the dimension will be :math:`2(2l+1) \\times 2(2l+1)`,
+        If ispin=True, the dimension will be :math:`2(2ll+1) \\times 2(2ll+1)`,
 
-        otherwise, it will be :math:`(2l+1) \\times (2l+1)`.
+        otherwise, it will be :math:`(2ll+1) \\times (2ll+1)`.
     """
-    norbs = 2 * l + 1
+    norbs = 2 * ll + 1
     lz = np.zeros((norbs, norbs), dtype=np.complex128)
-    for m in range(-l, l + 1):
-        lz[l + m, l + m] = m
+    for m in range(-ll, ll + 1):
+        lz[ll + m, ll + m] = m
     if ispin:
         lz_spin = np.zeros((2 * norbs, 2 * norbs), dtype=np.complex128)
         lz_spin[0:2 * norbs:2, 0:2 * norbs:2] = lz
@@ -185,14 +185,14 @@ def get_lz(l, ispin=False):
         return lz
 
 
-def get_orb_momentum(l, ispin=False):
+def get_orb_momentum(ll, ispin=False):
     """
     Get the matrix form of the orbital angular momentum
     operator :math:`l_x, l_y, l_z` in the complex spherical harmonics basis.
 
     Parameters
     ----------
-    l: int
+    ll: int
         Orbital angular momentum number.
     ispin: logical
         Whether including spin or not (default: False).
@@ -208,18 +208,18 @@ def get_orb_momentum(l, ispin=False):
 
         - res[2]: :math:`l_z`
 
-        If ispin=True, the dimension will be :math:`3 \\times 2(2l+1) \\times 2(2l+1)`,
+        If ispin=True, the dimension will be :math:`3 \\times 2(2ll+1) \\times 2(2ll+1)`,
 
-        otherwise, it will be :math:`3 \\times (2l+1) \\times (2l+1)`.
+        otherwise, it will be :math:`3 \\times (2ll+1) \\times (2ll+1)`.
     """
-    norbs = 2 * l + 1
+    norbs = 2 * ll + 1
     if ispin:
         res = np.zeros((3, 2*norbs, 2*norbs), dtype=np.complex128)
     else:
         res = np.zeros((3, norbs, norbs), dtype=np.complex128)
-    res[0] = get_lx(l, ispin)
-    res[1] = get_ly(l, ispin)
-    res[2] = get_lz(l, ispin)
+    res[0] = get_lx(ll, ispin)
+    res[1] = get_ly(ll, ispin)
+    res[2] = get_lz(ll, ispin)
 
     return res
 
@@ -250,101 +250,101 @@ def get_pauli():
     return sigma
 
 
-def get_sx(l):
+def get_sx(ll):
     """
     Get the matrix form of spin angular momentum operator :math:`s_x` in the
     complex spherical harmonics basis.
 
     Parameters
     ----------
-    l: int
+    ll: int
         Quantum number of orbital angular momentum.
 
     Returns
     -------
     sx: 2d complex array.
         Matrix form of :math:`s_x`, the dimension
-        is :math:`2(2l+1) \\times 2(2l+1)`,
+        is :math:`2(2ll+1) \\times 2(2ll+1)`,
 
-        Orbital order is: \\|-l,up\\>, \\|-l,down\\>, ...,
-        \\|+l, up\\>, \\|+l,down\\>.
+        Orbital order is: \\|-ll,up\\>, \\|-ll,down\\>, ...,
+        \\|+ll, up\\>, \\|+ll,down\\>.
     """
 
-    norbs = 2 * (2 * l + 1)
+    norbs = 2 * (2 * ll + 1)
     sx = np.zeros((norbs, norbs), dtype=np.complex128)
     sigma = get_pauli()
-    for i in range(2 * l + 1):
+    for i in range(2 * ll + 1):
         sx[2 * i:2 * i + 2, 2 * i:2 * i + 2] = sigma[0, :, :] / 2.0
 
     return sx
 
 
-def get_sy(l):
+def get_sy(ll):
     """
     Get the matrix form of spin angular momentum operator :math:`s_y` in the
     complex spherical harmonics basis.
 
     Parameters
     ----------
-    l: int
+    ll: int
         Quantum number of orbital angular momentum.
 
     Returns
     -------
     sy: 2d complex array.
         Matrix form of :math:`s_y`, the dimension
-        is :math:`2(2l+1) \\times 2(2l+1)`, spin order is:
+        is :math:`2(2ll+1) \\times 2(2ll+1)`, spin order is:
 
-        Orbital order is: \\|-l,up\\>, \\|-l,down\\>, ...,
-        \\|+l, up\\>, \\|+l,down\\>
+        Orbital order is: \\|-ll,up\\>, \\|-ll,down\\>, ...,
+        \\|+ll, up\\>, \\|+ll,down\\>
     """
 
-    norbs = 2 * (2 * l + 1)
+    norbs = 2 * (2 * ll + 1)
     sy = np.zeros((norbs, norbs), dtype=np.complex128)
     sigma = get_pauli()
-    for i in range(2 * l + 1):
+    for i in range(2 * ll + 1):
         sy[2 * i:2 * i + 2, 2 * i:2 * i + 2] = sigma[1, :, :] / 2.0
 
     return sy
 
 
-def get_sz(l):
+def get_sz(ll):
     """
     Get the matrix form of spin angular momentum operator :math:`s_z` in the
     complex spherical harmonics basis.
 
     Parameters
     ----------
-    l: int
+    ll: int
         Quantum number of orbital angular momentum.
 
     Returns
     -------
     sz: 2d complex array.
         Matrix form of :math:`s_z`, the dimension
-        is :math:`2(2l+1) \\times 2(2l+1)`.
+        is :math:`2(2ll+1) \\times 2(2ll+1)`.
 
-        Orbital order is: \\|-l,up\\>, \\|-l,down\\>, ...,
-        \\|+l, up\\>, \\|+l,down\\>
+        Orbital order is: \\|-ll,up\\>, \\|-ll,down\\>, ...,
+        \\|+ll, up\\>, \\|+ll,down\\>
     """
 
-    norbs = 2 * (2 * l + 1)
+    norbs = 2 * (2 * ll + 1)
     sz = np.zeros((norbs, norbs), dtype=np.complex128)
     sigma = get_pauli()
-    for i in range(2 * l + 1):
+    for i in range(2 * ll + 1):
         sz[2 * i:2 * i + 2, 2 * i:2 * i + 2] = sigma[2, :, :] / 2.0
 
     return sz
 
 
-def get_spin_momentum(l):
+def get_spin_momentum(ll):
     """
     Get the matrix form of the spin angular momentum
     operator :math:`s_x, s_y, s_z` in the complex spherical harmonics basis.
 
     Parameters
     ----------
-    l: int
+    ll: int
         Orbital angular momentum number.
 
     Returns
@@ -358,16 +358,16 @@ def get_spin_momentum(l):
 
         - res[2]: :math:`s_z`
 
-        the dimension is :math:`3 \\times 2(2l+1) \\times 2(2l+1)`,
+        the dimension is :math:`3 \\times 2(2ll+1) \\times 2(2ll+1)`,
 
-        Orbital order is: \\|-l,up\\>, \\|-l,down\\>, ...,
-        \\|+l, up\\>, \\|+l,down\\>
+        Orbital order is: \\|-ll,up\\>, \\|-ll,down\\>, ...,
+        \\|+ll, up\\>, \\|+ll,down\\>
     """
-    norbs = 2 * (2 * l + 1)
+    norbs = 2 * (2 * ll + 1)
     res = np.zeros((3, norbs, norbs), dtype=np.complex128)
-    res[0] = get_sx(l)
-    res[1] = get_sy(l)
-    res[2] = get_sz(l)
+    res[0] = get_sx(ll)
+    res[1] = get_sy(ll)
+    res[2] = get_sz(ll)
 
     return res
 

--- a/edrixs/basis_transform.py
+++ b/edrixs/basis_transform.py
@@ -449,7 +449,7 @@ def transform_utensor(umat, tmat):
     a1, a2, a3, a4 = np.nonzero(abs(umat) > 1E-16)
     nonzero = np.stack((a1, a2, a3, a4), axis=-1)
 
-    for ii, jj, kk, ll in nonzero:
+    for ii, jj, kk, mm in nonzero:
         for i in range(n):
             if abs(tmat[ii, i]) < 1E-16:
                 continue
@@ -462,12 +462,12 @@ def transform_utensor(umat, tmat):
                             if abs(tmat[kk, k]) < 1E-16:
                                 continue
                             else:
-                                for l in range(n):
-                                    umat_new[i, j, k, l] += (np.conj(tmat[ii, i]) *
+                                for m in range(n):
+                                    umat_new[i, j, k, m] += (np.conj(tmat[ii, i]) *
                                                              np.conj(tmat[jj, j]) *
-                                                             umat[ii, jj, kk, ll] *
+                                                             umat[ii, jj, kk, mm] *
                                                              tmat[kk, k] *
-                                                             tmat[ll, l])
+                                                             tmat[mm, m])
 
     return umat_new
 

--- a/edrixs/coulomb_utensor.py
+++ b/edrixs/coulomb_utensor.py
@@ -691,8 +691,8 @@ def get_umat_slater_3shells(shell_name, *args):
     for i in range(v1_norb + v3_norb):
         for j in range(v1_norb + v3_norb):
             for k in range(v1_norb + v3_norb):
-                for l in range(v1_norb + v3_norb):
-                    umat[aa[i], aa[j], aa[k], aa[l]] += umat_tmp[i, j, k, l]
+                for m in range(v1_norb + v3_norb):
+                    umat[aa[i], aa[j], aa[k], aa[m]] += umat_tmp[i, j, k, m]
 
     # v2-v3
     case = v2_name + v3_name
@@ -704,8 +704,8 @@ def get_umat_slater_3shells(shell_name, *args):
     for i in range(v2_norb + v3_norb):
         for j in range(v2_norb + v3_norb):
             for k in range(v2_norb + v3_norb):
-                for l in range(v2_norb + v3_norb):
-                    umat[aa[i], aa[j], aa[k], aa[l]] += umat_tmp[i, j, k, l]
+                for m in range(v2_norb + v3_norb):
+                    umat[aa[i], aa[j], aa[k], aa[m]] += umat_tmp[i, j, k, m]
 
     return umat
 

--- a/edrixs/iostream.py
+++ b/edrixs/iostream.py
@@ -104,18 +104,18 @@ def write_tensor_5(tensor, fname, only_nonzeros=False, tol=1E-10, fmt_int='{:10d
     for i in range(n1):
         for j in range(n2):
             for k in range(n3):
-                for l in range(n4):
+                for r in range(n4):
                     for m in range(n5):
-                        if only_nonzeros and abs(tensor[i, j, k, l, m]) < tol:
+                        if only_nonzeros and abs(tensor[i, j, k, r, m]) < tol:
                             continue
                         if is_cmplx:
                             fmt_string = (fmt_int + space) * 5 + (fmt_float + space) * 2 + '\n'
-                            f.write(fmt_string.format(i + 1, j + 1, k + 1, l + 1, m + 1,
-                                    tensor[i, j, k, l, m].real, tensor[i, j, k, l, m].imag))
+                            f.write(fmt_string.format(i + 1, j + 1, k + 1, r + 1, m + 1,
+                                    tensor[i, j, k, r, m].real, tensor[i, j, k, r, m].imag))
                         else:
                             fmt_string = (fmt_int + space) * 5 + fmt_float + space + '\n'
-                            f.write(fmt_string.format(i + 1, j + 1, k + 1, l + 1, m + 1,
-                                    tensor[i, j, k, l, m]))
+                            f.write(fmt_string.format(i + 1, j + 1, k + 1, r + 1, m + 1,
+                                    tensor[i, j, k, r, m]))
     f.close()
 
 

--- a/edrixs/iostream.py
+++ b/edrixs/iostream.py
@@ -80,16 +80,16 @@ def write_tensor_4(tensor, fname, only_nonzeros=False, tol=1E-10, fmt_int='{:10d
     for i in range(n1):
         for j in range(n2):
             for k in range(n3):
-                for l in range(n4):
-                    if only_nonzeros and abs(tensor[i, j, k, l]) < tol:
+                for m in range(n4):
+                    if only_nonzeros and abs(tensor[i, j, k, m]) < tol:
                         continue
                     if is_cmplx:
                         fmt_string = (fmt_int + space) * 4 + (fmt_float + space) * 2 + '\n'
-                        f.write(fmt_string.format(i + 1, j + 1, k + 1, l + 1,
-                                tensor[i, j, k, l].real, tensor[i, j, k, l].imag))
+                        f.write(fmt_string.format(i + 1, j + 1, k + 1, m + 1,
+                                tensor[i, j, k, m].real, tensor[i, j, k, m].imag))
                     else:
                         fmt_string = (fmt_int + space) * 4 + fmt_float + space + '\n'
-                        f.write(fmt_string.format(i + 1, j + 1, k + 1, l + 1, tensor[i, j, k, l]))
+                        f.write(fmt_string.format(i + 1, j + 1, k + 1, m + 1, tensor[i, j, k, m]))
     f.close()
 
 

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -1986,9 +1986,9 @@ def ed_siam_fort(comm, shell_name, nbath, *, siam_type=0, v_noccu=1, static_core
     for i in range(v_norb+c_norb):
         for j in range(v_norb+c_norb):
             for k in range(v_norb+c_norb):
-                for l in range(v_norb+c_norb):
-                    umat_i[indx[i], indx[j], indx[k], indx[l]] = umat_tmp_i[i, j, k, l]
-                    umat_n[indx[i], indx[j], indx[k], indx[l]] = umat_tmp_n[i, j, k, l]
+                for m in range(v_norb+c_norb):
+                    umat_i[indx[i], indx[j], indx[k], indx[m]] = umat_tmp_i[i, j, k, m]
+                    umat_n[indx[i], indx[j], indx[k], indx[m]] = umat_tmp_n[i, j, k, m]
     if rank == 0:
         write_umat(umat_i, 'coulomb_i.in')
         write_umat(umat_n, 'coulomb_n.in')

--- a/examples/cpc/anderson_impurity/get_inputs.py
+++ b/examples/cpc/anderson_impurity/get_inputs.py
@@ -81,9 +81,9 @@ def get_hopping_coulomb():
     for i in range(10):
         for j in range(10):
             for k in range(10):
-                for l in range(10):
-                    umat_n[id2[i], id2[j], id2[k], id2[l]
-                           ] = umat_tmp[id1[i], id1[j], id1[k], id1[l]]
+                for ll in range(10):
+                    umat_n[id2[i], id2[j], id2[k], id2[ll]
+                           ] = umat_tmp[id1[i], id1[j], id1[k], id1[ll]]
 
     emat_i = np.zeros((norbs, norbs), dtype=np.complex128)
     emat_n = np.zeros((norbs, norbs), dtype=np.complex128)

--- a/examples/cpc/two_site_cluster/get_inputs.py
+++ b/examples/cpc/two_site_cluster/get_inputs.py
@@ -80,9 +80,9 @@ def get_hopping_coulomb(locaxis):
         for i in range(12):
             for j in range(12):
                 for k in range(12):
-                    for l in range(12):
+                    for ll in range(12):
                         umat_n[indx[m, i], indx[m, j], indx[m, k],
-                               indx[m, l]] += umat_t2gp_n[i, j, k, l]
+                               indx[m, ll]] += umat_t2gp_n[i, j, k, ll]
 
     emat_i = np.zeros((norbs, norbs), dtype=np.complex128)
     emat_n = np.zeros((norbs, norbs), dtype=np.complex128)

--- a/examples/more/RIXS/Ba3InIr2O9/t2g_two_site_cluster/run_ed.py
+++ b/examples/more/RIXS/Ba3InIr2O9/t2g_two_site_cluster/run_ed.py
@@ -56,9 +56,9 @@ if __name__ == "__main__":
         for i in range(12):
             for j in range(12):
                 for k in range(12):
-                    for l in range(12):
+                    for ll in range(12):
                         umat_n[m, indx[m, i], indx[m, j], indx[m, k],
-                               indx[m, l]] += umat_t2gp_n[i, j, k, l]
+                               indx[m, ll]] += umat_t2gp_n[i, j, k, ll]
 
     emat_i = np.zeros((norbs, norbs), dtype=np.complex128)
     emat_n = np.zeros((2, norbs, norbs), dtype=np.complex128)


### PR DESCRIPTION
Due to requirement of the new version of `pycodestyle`, the variable `l` is not allowed, so I have removed all of them. 