### PR TITLE
pin jupyterlab version and build widgets

### DIFF
--- a/docker/Dockerfile_base
+++ b/docker/Dockerfile_base
@@ -43,7 +43,7 @@ RUN apt-get update \
     && cd .. \
     && rm -rf arpack-ng-3.6.3 3.6.3.tar.gz \
     # install python deps
-    && pip install numpy scipy sympy matplotlib sphinx mpi4py jupyter jupyterlab prompt-toolkit==1.0.15 \
+    && pip install numpy scipy sympy matplotlib sphinx mpi4py jupyter jupyterlab==2.1.3 prompt-toolkit==1.0.15 \
     # set env
     && echo "export LD_LIBRARY_PATH=/usr/local/lib:\$LD_LIBRARY_PATH" >> ~/.bashrc  \
     && echo "export LD_LIBRARY_PATH=/usr/local/lib:\$LD_LIBRARY_PATH" >> /home/rixs/.bashrc

--- a/docker/Dockerfile_interactive
+++ b/docker/Dockerfile_interactive
@@ -9,6 +9,7 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
     && apt install -y nodejs \
     && pip install ipympl==0.5.* \
     # Also activate ipywidgets extension for JupyterLab
+    && jupyter nbextension enable --py widgetsnbextension --sys-prefix \
     # Check this URL for most recent compatibilities
     # https://github.com/jupyter-widgets/ipywidgets/tree/master/packages/jupyterlab-manager
     && jupyter labextension install @jupyter-widgets/jupyterlab-manager@^2.0.0 --no-build \


### PR DESCRIPTION
This should fix the dockerhub build.

Since it works locally and it's hard to debug these issues by reading the code, I'm likely to merge it soon.