### PR TITLE
link to jupyterlab

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,14 +9,14 @@ edrixs
         :target: https://pypi.python.org/pypi/edrixs
 
 .. image:: https://mybinder.org/badge_logo.svg
- :target: https://mybinder.org/v2/gh/NSLS-II/edrixs.git/master
+ :target: https://mybinder.org/v2/gh/NSLS-II/edrixs.git/master?urlpath=lab
 
 An open source toolkit for simulating RIXS spectra based on exact diagonalization (ED) for strongly correlated materials.
 `It is developed <https://www.bnl.gov/comscope/software/EDRIXS.php>`_ as part of `COMSCOPE project <https://www.bnl.gov/comscope/software/comsuite.php/>`_ in the Center for Computational Material Spectroscopy and Design, Brookhaven National Laboratory
 
 * Free software: GNU General Public License Version 3
 * Documentation: https://nsls-ii.github.io/edrixs.
-* Launch a `MyBinder Session <https://www.bnl.gov/comscope/software/EDRIXS.php>`_ to try the code.
+* Launch a `MyBinder Session <https://mybinder.org/v2/gh/NSLS-II/edrixs.git/master?urlpath=lab>`_ to try the code.
 
 Features
 --------


### PR DESCRIPTION
Different link is needed to open jupyterlab rather than older jupyter notebook. 