### PR TITLE
add ffmpeg to docker_interactive

### DIFF
--- a/docker/Dockerfile_interactive
+++ b/docker/Dockerfile_interactive
@@ -3,7 +3,7 @@ WORKDIR /project
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
     && apt-get update \
-    && apt-get install -y -q --no-install-recommends curl \
+    && apt-get install -y -q --no-install-recommends curl ffmpeg \
     && curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash - \
     && apt install -y git \
     && apt install -y nodejs \


### PR DESCRIPTION
ffmpeg is needed for matplotlib animations and is now included in dockerfile_interactive. 