### PR TITLE
error in get_inputs.py AIM example

### DIFF
--- a/examples/cpc/anderson_impurity/get_inputs.py
+++ b/examples/cpc/anderson_impurity/get_inputs.py
@@ -11,7 +11,7 @@ def build_dirs():
     for path in ["search_gs", "ed", "xas", "rixs_pp", "rixs_ps"]:
         if os.path.isdir(path):
             shutil.rmtree(path)
-        os.mkdirs(path)
+        os.mkdir(path)
 
 
 def set_config():


### PR DESCRIPTION
Pretty sure this is a typo that needs correcting as `os.mkdirs` does not exist. 