### PR TITLE
update AIM example description

### DIFF
--- a/examples/sphinx/example_2_AIM_XAS.py
+++ b/examples/sphinx/example_2_AIM_XAS.py
@@ -2,33 +2,42 @@
 """
 Anderson impurity model for NiO XAS
 ================================================================================
-Here we calculate the :math:`L`-edge XAS spectrum of an Anderson impurity model.
-This is sometimes also called a charge-transfer multiplet model.
-Everyone's favorite test case for this is NiO and we won't risk being original!
+Here we calculate the :math:`L`-edge XAS spectrum of an Anderson impurity model,
+which is sometimes also called a charge-transfer multiplet model. This model
+considers a set of correlated orbitals, often called the impurity or metal
+states, that hybridize with a set of uncorrelated orbitals, often called the
+ligands or bath states. Everyone's favorite test case for x-ray spectroscopic
+calculations of the Anderson impurity model is NiO and we won't risk being
+original! This means that our correlated states will
+be the Ni :math:`3d` orbitals and the uncorrelated states come from O
+:math:`2p` orbitals. The fact that we include these interactions means that our
+spectrum can include processes where electrons transition from the bath to the
+impurity, as such the Anderson Impurity Model is often more accurate than atomic
+models, especially if the material has strong covalency.
 
-The model considers the Ni :math:`3d` orbitals interacting with a surrounding 
-set of O :math:`2p` orbitals. NiO has a rocksalt structure in which all Ni 
-atoms are surrounded by six O atoms in cubic symmetry. Based on this, 
-one would assume that the NiO cluster used to simulate the crystal would 
-need to contain :math:`6` spin-orbitals per O 
-:math:`\\times 6` O atoms :math:`=36` oxygen 
-spin-orbitals. As explained by, for example, Maurits Haverkort et al. in
-[1]_ only 10 of these orbitals
-interact with the Ni atom and solving the problem with :math:`10+10 = 20`
-spin-orbitals is far faster. For more general calculations of this type you 
-may see the Ni states being referred to as the impurity or metal and the
-O states being called the bath or ligand.
+When defining the bath states, it is useful to use the so-called
+symmetry adapted linear combinations of orbitals as the basis. These states
+take into account the symmetry relationships between the different bath atom
+orbitals and the fact that there are bath orbital combinations that do not
+interact with the impurity by symmetry. By doing this the problem can be
+represented with fewer orbitals, which makes the calculation far more efficient.
+The standard EDRIXS solver that we will use, assumes that the bath states are
+represented by an integer number of bath sites set by :code:`nbath`, each of
+which hosts a the same number of spin-orbits as the impurity e.g. 10 for a
+:math:`d`-electron material.
 
-We consider on-site crystal field, spin-orbit coupling, magnetic exchange, and
-Coulomb interactions for the impurity, which is hybridized with the bath by
-defining hopping parameters and an energy difference between the impurity 
-and bath. In this way, our spectrum can include processes where
-electrons transition from the bath to the impurity.
+NiO has a rocksalt structure in which all Ni atoms are surrounded by six O
+atoms. This NiO cluster used to simulate the
+crystal would then contain 10 Ni :math:`3d` spin-orbitals and :math:`6`
+spin-orbitals per O :math:`\\times 6` O atoms :math:`=36` oxygen
+spin-orbitals. As explained by, for example, Maurits Haverkort
+et al. in [1]_ symmetry allows us to represent the bath with 10 symmetry
+adapted linear combinations of the different O :math:`p_x, p_y, p_z` states.
+The crystal field and hopping parameters for
+such a calculation can be obtained by post-processing DFT calculations. We will
+use values for NiO from [1]_. If you use values from a paper the relevant
+references should, of course, be cited.
 
-The crystal field and hopping parameters for such a calculation can be
-obtained from DFT. We will use values for NiO from
-[1]_. If you use values from a paper the relevant references should,
-of course, be cited.
 """
 import edrixs
 import numpy as np
@@ -37,32 +46,31 @@ import matplotlib.pyplot as plt
 ################################################################################
 # Number of electrons
 # ------------------------------------------------------------------------------
-# When formulating problems of this type, one usually thinks of a nominal 
+# When formulating problems of this type, one usually thinks of a nominal
 # valence for the impurity atom in this case :code:`nd = 8` and assume that the
-# bath of :code:`norb_bath  = 10` O spin-orbitals is full. The solver that we will
-# use can simulate multiple bath sites. In our case we specify 
+# bath is full. The solver that we will
+# use can simulate multiple bath sites. In our case we specify
 # :code:`nbath  = 1` sites. Electrons will be able to transition from O to Ni
-# during our calculation, but the total number of valance electrons :code:`v_noccu`
-# will be conserved.
+# during our calculation, but the total number of valance electrons
+# :code:`v_noccu` will be conserved.
 nd = 8
 norb_d = 10
-norb_bath  = 10 # number of spin-orbitals for each bath site
 nbath = 1
 v_noccu  = nd + nbath*norb_d
 shell_name = ('d', 'p') # valence and core shells for XAS calculation
 
 ################################################################################
-# Coulomb interactions 
+# Coulomb interactions
 # ------------------------------------------------------------------------------
 # The atomic Coulomb interactions are usually initialized based on Hartree-Fock
-# calculations from, for example,  
+# calculations from, for example,
 # `Cowan's code <https://www.tcd.ie/Physics/people/Cormac.McGuinness/Cowan/>`_.
 # edrixs has a database of these.
 info  = edrixs.utils.get_atom_data('Ni', '3d', nd, edge='L3')
 
 ################################################################################
-# The atomic values are typically scaled to account for screening in the solid. 
-# Here we use 80% scaling. Let's write these out in full, so that nothing is 
+# The atomic values are typically scaled to account for screening in the solid.
+# Here we use 80% scaling. Let's write these out in full, so that nothing is
 # hidden. Values for :math:`U_{dd}` and :math:`U_{dp}` are those of Ref. [1]_
 # obtained by comparing theory and experiment [2]_ [3]_.
 scale_dd = 0.8
@@ -85,16 +93,16 @@ slater = ([F0_dd, F2_dd, F4_dd],  # initial
 # Charge-transfer energy scales
 # ------------------------------------------------------------------------------
 # The charge-transfer :math:`\Delta` and Coulomb :math:`U_{dd}` :math:`U_{dp}`
-# parameters determine the centers of the different electronic configurations 
+# parameters determine the centers of the different electronic configurations
 # before they are split. Note that as electrons are moved one has to pay energy
 # costs associated with both charge-transfer and Coulomb interactions. The
-# energy splitting between the bath and impurity is consequently not simply 
+# energy splitting between the bath and impurity is consequently not simply
 # :math:`\Delta`. One must therefore determine the energies by solving
-# a set of linear equations. See the :ref:`edrixs.utils functions <utils>` 
+# a set of linear equations. See the :ref:`edrixs.utils functions <utils>`
 # for details. We can call these functions to get the impurity energy
 # :math:`E_d`, bath energy :math:`E_L`, impurity energy with a core hole
-# :math:`E_{dc}`, bath energy with a core hole :math:`E_{Lc}` and the 
-# core hole energy :math:`E_p`. The 
+# :math:`E_{dc}`, bath energy with a core hole :math:`E_{Lc}` and the
+# core hole energy :math:`E_p`. The
 # :code:`if __name__ == '__main__'` code specifies that this command
 # should only be executed if the file is explicitly run.
 Delta = 4.7
@@ -122,10 +130,10 @@ c_soc = info['c_soc']
 # ------------------------------------------------------------------------------
 # edrixs uses complex spherical harmonics as its default basis set. If we want to
 # use another basis set, we need to pass a matrix to the solver, which transforms
-# from complex spherical harmonics into the basis we use. 
-# The solver will use this matrix when implementing the Coulomb interactions 
+# from complex spherical harmonics into the basis we use.
+# The solver will use this matrix when implementing the Coulomb interactions
 # using the :code:`slater` list of Coulomb parameters.
-# Here it is easiest to 
+# Here it is easiest to
 # use real harmonics. We make the complex harmonics to real harmonics transformation
 # matrix via
 trans_c2n = edrixs.tmat_c2r('d',True)
@@ -134,8 +142,8 @@ trans_c2n = edrixs.tmat_c2r('d',True)
 # The crystal field and SOC needs to be passed to the solver by constructing
 # the impurity matrix in the real harmonic basis. For cubic symmetry, we need
 # to set the energies of the orbitals along the
-# diagonal of the matrix. These need to be in pairs as there are two 
-# spin-orbitals for each orbital energy. Python 
+# diagonal of the matrix. These need to be in pairs as there are two
+# spin-orbitals for each orbital energy. Python
 # `list comprehension <https://realpython.com/list-comprehension-python/>`_
 # and
 # `numpy indexing <https://numpy.org/doc/stable/reference/arrays.indexing.html>`_
@@ -154,7 +162,7 @@ orbital_energies = np.array([e for orbital_energy in
                              for e in [orbital_energy]*2])
 
 
-CF[diagonal_indices, diagonal_indices] = orbital_energies                  
+CF[diagonal_indices, diagonal_indices] = orbital_energies
 
 ################################################################################
 # The valence band SOC is constructed in the normal way and transformed into the
@@ -172,7 +180,7 @@ imp_mat = CF + soc + E_d_mat
 imp_mat_n = CF + soc + E_dc_mat
 
 ################################################################################
-# The energy level of the bath(s) is described by a matrix where the row index 
+# The energy level of the bath(s) is described by a matrix where the row index
 # denotes which bath and the column index denotes which orbital. Here we have
 # only one bath, with 10 spin-orbitals. We initialize the matrix to
 # :code:`norb_d` and then split the energies according to :code:`ten_dq_bath`.
@@ -193,10 +201,10 @@ bath_level_n[0, 8:] -= ten_dq_bath*.4  # xy
 # and the impurity. This is called either :math:`V` or :math:`T` in the
 # literature and matrix sign can either be positive or negative based.
 # This is the same shape as the bath matrix. We take our
-# values from Maurits Haverkort et al.'s DFT calculations [1]_. 
+# values from Maurits Haverkort et al.'s DFT calculations [1]_.
 Veg = 2.06
 Vt2g = 1.21
-    
+
 hyb = np.zeros((nbath, norb_d), dtype=np.complex)
 hyb[0, :2] = Veg  # 3z2-r2
 hyb[0, 2:6] = Vt2g  # zx/yz
@@ -216,14 +224,14 @@ temperature = 300
 thin = 0 / 180.0 * np.pi
 phi = 0.0
 ################################################################################
-# these are with respect to the crystal field :math:`z` and :math:`x` axes 
+# these are with respect to the crystal field :math:`z` and :math:`x` axes
 # written above. (That is, unless you specify the :code:`loc_axis` parameter
 # described in the :code:`edrixs.xas_siam_fort` function documentation.)
 
 ################################################################################
 # The spectrum in the raw calculation is offset by the energy involved with the
 # core hole state, which is roughly :math:`5 E_p`, so we offset the spectrum by
-# this and use :code:`om_shift` as an adjustable parameters for comparing 
+# this and use :code:`om_shift` as an adjustable parameters for comparing
 # theory to experiment. We also use this to specify :code:`ominc_xas`
 # the range we want to compute the spectrum over. The core hole lifetime
 # broadening also needs to be set via :code:`gamma_c_stat`.
@@ -236,26 +244,26 @@ ominc_xas = om_shift + np.linspace(-15, 25, 1000)
 # You can either pass a constant value or an array the same size as
 # :code:`om_shift` with varying values to simulate, for example, different state
 # lifetimes for higher energy states.
-gamma_c = np.full(ominc_xas.shape, 0.48/2)   
+gamma_c = np.full(ominc_xas.shape, 0.48/2)
 
 ################################################################################
 # Magnetic field is a three-component vector in eV specified with respect to the
 # same local axis as the x-ray beam. Since we are considering a powder here
 # we create an isotropic normalized vector. :code:`on_which = 'both'` specifies to
 # apply the operator to the total spin plus orbital angular momentum as is
-# appropriate for a physical external magnetic field. You can use 
+# appropriate for a physical external magnetic field. You can use
 # :code:`on_which = 'spin'` to apply the operator to spin in order to simulate
 # magnetic order in the sample. The value of the Bohr Magneton can
 # be useful for converting here :math:`\mu_B = 5.7883818012\times 10^{−5}`.
 # For this example, we will account for magnetic order in the sample by
 ext_B = np.array([0.00, 0.00, 0.12])
 on_which = 'spin'
-    
+
 ################################################################################
 # The number crunching uses
-# `mpi4py <https://mpi4py.readthedocs.io/en/stable/>`_. You can safely ignore 
-# this for most purposes, but see 
-# `Y. L. Wang et al., Computer Physics Communications 243, 151-165 (2019) <https://doi.org/10.1016/j.cpc.2019.04.018>`_ 
+# `mpi4py <https://mpi4py.readthedocs.io/en/stable/>`_. You can safely ignore
+# this for most purposes, but see
+# `Y. L. Wang et al., Computer Physics Communications 243, 151-165 (2019) <https://doi.org/10.1016/j.cpc.2019.04.018>`_
 # if you would like more details.
 # The main thing to remember is that you should call this script via::
 #
@@ -267,17 +275,17 @@ if __name__ == '__main__':
     from mpi4py import MPI
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
-    size = comm.Get_size() 
+    size = comm.Get_size()
 
 ################################################################################
 # Calling the :code:`edrixs.ed_siam_fort` solver will find the ground state and
 # write input files, *hopping_i.in*, *hopping_n.in*, *coulomb_i.in*, *coulomb_n.in*
 # for following XAS (or RIXS) calculation. We need to specify :code:`siam_type=0`
 # which says that we will pass *imp_mat*, *bath_level* and *hyb*.
-# We need to specify :code:`do_ed = 1`. For this example, we cannot use 
+# We need to specify :code:`do_ed = 1`. For this example, we cannot use
 # :code:`do_ed = 0` for a ground state search as we have set the impurity and
 # bath energy levels artificially, which means edrixs will have trouble to know
-# which subspace to search to find the ground state. 
+# which subspace to search to find the ground state.
 if __name__ == '__main__':
     do_ed = 1
     eval_i, denmat, noccu_gs = edrixs.ed_siam_fort(
@@ -287,7 +295,7 @@ if __name__ == '__main__':
         on_which=on_which, trans_c2n=trans_c2n, v_noccu=v_noccu, do_ed=do_ed,
         ed_solver=2, neval=50, nvector=3, ncv=100, idump=True)
 ################################################################################
-# Let's check that we have all the electrons we think we have and print how 
+# Let's check that we have all the electrons we think we have and print how
 # the electron are distributed between the Ni (impurity) and O (bath).
 if __name__ == '__main__':
     assert np.abs(noccu_gs - v_noccu) < 1e-6
@@ -296,12 +304,12 @@ if __name__ == '__main__':
     print('Impurity occupation = {:.6f}\n'.format(impurity_occupation))
     print('Bath occupation = {:.6f}\n'.format(bath_occupation))
 ################################################################################
-# We see that 0.18 electrons move from the O to the Ni in the ground state. 
-# 
+# We see that 0.18 electrons move from the O to the Ni in the ground state.
+#
 # We can now construct the XAS spectrum edrixs by applying a transition
-# operator to create the excited state. We need to be careful to specify how 
-# many of the low energy states are thermally populated. In this case 
-# :code:`num_gs=3`. This can be determined by inspecting the function output. 
+# operator to create the excited state. We need to be careful to specify how
+# many of the low energy states are thermally populated. In this case
+# :code:`num_gs=3`. This can be determined by inspecting the function output.
 if __name__ == '__main__':
     xas, xas_poles = edrixs.xas_siam_fort(
         comm, shell_name, nbath, ominc_xas, gamma_c=gamma_c, v_noccu=v_noccu, thin=thin,
@@ -323,9 +331,9 @@ if __name__ == '__main__':
 ##############################################################################
 #
 # .. rubric:: Footnotes
-# 
+#
 # .. [1] Maurits Haverkort et al
-#        `Phys. Rev. B 85, 165113 (2012) <https://doi.org/10.1103/PhysRevB.85.165113>`_. 
+#        `Phys. Rev. B 85, 165113 (2012) <https://doi.org/10.1103/PhysRevB.85.165113>`_.
 # .. [2] A. E. Bocquet et al.,
 #        `Phys. Rev. B 53, 1161 (1996) <https://doi.org/10.1103/PhysRevB.53.1161>`_
 # .. [3] Arata Tanaka, and Takeo Jo,

--- a/examples/sphinx/example_2_AIM_XAS.py
+++ b/examples/sphinx/example_2_AIM_XAS.py
@@ -55,6 +55,7 @@ import matplotlib.pyplot as plt
 # :code:`v_noccu` will be conserved.
 nd = 8
 norb_d = 10
+norb_bath = 10
 nbath = 1
 v_noccu  = nd + nbath*norb_d
 shell_name = ('d', 'p') # valence and core shells for XAS calculation

--- a/examples/sphinx/example_3_GS_analysis.py
+++ b/examples/sphinx/example_3_GS_analysis.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 """
-Ground state analysis for NiO 
+Ground state analysis for NiO
 ================================================================================
-This example follows the :ref:`sphx_glr_auto_examples_example_2_AIM_XAS.py` 
+This example follows the :ref:`sphx_glr_auto_examples_example_2_AIM_XAS.py`
 example and considers the same model. This time we show how to analyze
 the wavevectors in terms of a
 :math:`\\alpha |d^8L^{10}> + \\beta |d^9L^9> \\gamma |d^{10}L^8>`
@@ -18,31 +18,31 @@ import matplotlib.pyplot as plt
 import scipy
 import example_2_AIM_XAS
 import importlib
-importlib.reload(example_2_AIM_XAS)
+_ = importlib.reload(example_2_AIM_XAS)
 
 ################################################################################
 # Hamiltonian
 # ------------------------------------------------------------------------------
-# edrixs builds model Hamiltonians based on two fermion and four fermion terms. 
-# The four fermion terms come from Coulomb interactions and will be 
+# edrixs builds model Hamiltonians based on two fermion and four fermion terms.
+# The four fermion terms come from Coulomb interactions and will be
 # assigned to :code:`umat`. All other interactions contribute to two fermion
-# terms in :code:`emat`. 
+# terms in :code:`emat`.
 #
 #    .. math::
 #     \begin{equation}
 #     \hat{H}_{i} = \sum_{\alpha,\beta} t_{\alpha,\beta}
-#     \hat{f}^{\dagger}_{\alpha} \hat{f}_{\beta} 
-#     + \sum_{\alpha,\beta,\gamma,\delta} U_{\alpha,\beta,\gamma,\delta} 
+#     \hat{f}^{\dagger}_{\alpha} \hat{f}_{\beta}
+#     + \sum_{\alpha,\beta,\gamma,\delta} U_{\alpha,\beta,\gamma,\delta}
 #     \hat{f}^{\dagger}_{\alpha}\hat{f}^{\dagger}_{\beta}
 #     \hat{f}_{\gamma}\hat{f}_{\delta},
-#     \end{equation} 
+#     \end{equation}
 #
 
 ################################################################################
 # Import parameters
 # ------------------------------------------------------------------------------
 # Let's get the parammeters we need from the
-# :ref:`sphx_glr_auto_examples_example_2_AIM_XAS.py` example. We need to 
+# :ref:`sphx_glr_auto_examples_example_2_AIM_XAS.py` example. We need to
 # consider :code:`ntot=20` spin-orbitals
 # for this problem.
 
@@ -51,9 +51,8 @@ from example_2_AIM_XAS import (F0_dd, F2_dd, F4_dd,
                                imp_mat, CF, bath_level,
                                hyb, ext_B, trans_c2n)
 ntot = 20
-                               
 ################################################################################
-# Four fermion matrix 
+# Four fermion matrix
 # ------------------------------------------------------------------------------
 # The Coulomb interactions in the :math:`d` shell of this problem are described
 # by a :math:`10\times10\times10\times10` matrix. We
@@ -70,7 +69,7 @@ umat[:norb_d, :norb_d, :norb_d, :norb_d] += umat_delectrons
 ################################################################################
 # Two fermion matrix
 # ------------------------------------------------------------------------------
-# Previously we made a :math:`10\times10` two-fermion matrix describing the 
+# Previously we made a :math:`10\times10` two-fermion matrix describing the
 # :math:`d`-shell interactions. Keep in mind we did this in the real harmonic
 # basis. We need to specify the two-fermion matrix for
 # the full problem :math:`20\times20` spin-orbitals in size.
@@ -79,10 +78,10 @@ emat_rhb[0:norb_d, 0:norb_d] += imp_mat
 
 ################################################################################
 # The :code:`bath_level` energies need to be applied to the diagonal of the
-# last :math:`10\times10` region of the matrix. 
+# last :math:`10\times10` region of the matrix.
 indx = np.arange(norb_d, norb_d*2)
 emat_rhb[indx, indx] += bath_level[0]
-   
+
 ################################################################################
 # The :code:`hyb` terms mix the impurity and bath states and are therefore
 # applied to the off-diagonal terms of :code:`emat`.
@@ -104,7 +103,7 @@ emat_chb = edrixs.cb_op(emat_rhb, tmat)
 
 ################################################################################
 # The spin exchange is built from the spin operators and the effective field
-# is applied to the :math:`d`-shell region of the matrix. 
+# is applied to the :math:`d`-shell region of the matrix.
 v_orbl = 2
 sx = edrixs.get_sx(v_orbl)
 sy = edrixs.get_sy(v_orbl)
@@ -115,8 +114,8 @@ emat_chb[0:norb_d, 0:norb_d] += zeeman
 ################################################################################
 # Build the Fock basis and Hamiltonain and Diagonalize
 # ------------------------------------------------------------------------------
-# We create the fock basis and build the Hamiltonian using the full set of 
-# :math:`20` spin orbitals,  specifying that they are occuplied by :math:`18` 
+# We create the fock basis and build the Hamiltonian using the full set of
+# :math:`20` spin orbitals,  specifying that they are occuplied by :math:`18`
 # electrons. See the :ref:`sphx_glr_auto_examples_example_0_ed_calculator.py`
 # example for more details if needed. We also set the ground state to zero
 # energy.
@@ -149,8 +148,8 @@ print(message.format(alphas[0], betas[0], gammas[0]))
 ################################################################################
 # Plot
 # ------------------------------------------------------------------------------
-# Let's look how :math:`\alpha`, :math:`\beta`, and :math:`\gamma` vary with 
-# energy. 
+# Let's look how :math:`\alpha`, :math:`\beta`, and :math:`\gamma` vary with
+# energy.
 
 fig, ax = plt.subplots()
 
@@ -167,5 +166,5 @@ plt.show()
 ################################################################################
 # We see that the ligand states are mixed into the ground state, but the
 # majority of the weight for the :math:`L^9` and :math:`L^8` states
-# live at :math:`\Delta` and :math:`2\Delta`. With a lot of additional 
+# live at :math:`\Delta` and :math:`2\Delta`. With a lot of additional
 # structure from the other interactions.


### PR DESCRIPTION
This expands our AIM example a bit with the aim of describing the way the bath orbitals are represented. 

The attachment renders the example, which might make it easier to read. 

[Anderson impurity model for NiO XAS — edrixs documentation.pdf](https://github.com/NSLS-II/edrixs/files/5570682/Anderson.impurity.model.for.NiO.XAS.edrixs.documentation.pdf)
