### PR TITLE
fix warnings

### DIFF
--- a/edrixs/angular_momentum.py
+++ b/edrixs/angular_momentum.py
@@ -577,7 +577,7 @@ def get_wigner_dmat(quant_2j, alpha, beta, gamma):
     from sympy.physics.quantum.spin import Rotation
     from sympy import N, S
     ndim = quant_2j + 1
-    result = np.zeros((ndim, ndim), dtype=np.complex)
+    result = np.zeros((ndim, ndim), dtype=complex)
     # For j=1/2, we use different orbital order: first +1/2, then -1/2
     if quant_2j == 1:
         for i, mi in enumerate(range(quant_2j, -quant_2j-1, -2)):
@@ -610,13 +610,13 @@ def cf_cubic_d(ten_dq):
         The matrix form of crystal field Hamiltonian in complex harmonics basis.
     """
 
-    tmp = np.zeros((5, 5), dtype=np.complex)
+    tmp = np.zeros((5, 5), dtype=complex)
     tmp[0, 0] = 0.6 * ten_dq  # dz2
     tmp[1, 1] = -0.4 * ten_dq  # dzx
     tmp[2, 2] = -0.4 * ten_dq  # dzy
     tmp[3, 3] = 0.6 * ten_dq  # dx2-y2
     tmp[4, 4] = -0.4 * ten_dq  # dxy
-    cf = np.zeros((10, 10), dtype=np.complex)
+    cf = np.zeros((10, 10), dtype=complex)
     cf[0:10:2, 0:10:2] = tmp
     cf[1:10:2, 1:10:2] = tmp
 
@@ -649,14 +649,14 @@ def cf_tetragonal_d(ten_dq, d1, d3):
     ds = (d3 + d1) / 7.0
     dq = ten_dq / 10.0
 
-    tmp = np.zeros((5, 5), dtype=np.complex)
+    tmp = np.zeros((5, 5), dtype=complex)
     tmp[0, 0] = 6 * dq - 2 * ds - 6 * dt  # d3z2-r2
     tmp[1, 1] = -4 * dq - 1 * ds + 4 * dt  # dzx
     tmp[2, 2] = -4 * dq - 1 * ds + 4 * dt  # dzy
     tmp[3, 3] = 6 * dq + 2 * ds - 1 * dt  # dx2-y2
     tmp[4, 4] = -4 * dq + 2 * ds - 1 * dt  # dxy
 
-    cf = np.zeros((10, 10), dtype=np.complex)
+    cf = np.zeros((10, 10), dtype=complex)
     cf[0:10:2, 0:10:2] = tmp
     cf[1:10:2, 1:10:2] = tmp
 
@@ -684,7 +684,7 @@ def cf_trigonal_t2g(delta):
     tmp = np.array([[0, delta, delta],
                     [delta, 0, delta],
                     [delta, delta, 0]])
-    cf = np.zeros((6, 6), dtype=np.complex)
+    cf = np.zeros((6, 6), dtype=complex)
     cf[0:6:2, 0:6:2] += tmp
     cf[1:6:2, 1:6:2] += tmp
     cf[:, :] = cb_op(cf, tmat_r2c('t2g', True))
@@ -714,14 +714,14 @@ def cf_square_planar_d(ten_dq, ds):
     cf: 2d complex array, shape=(10, 10)
         The matrix form of crystal field Hamiltonian in complex harmonics basis.
     """
-    tmp = np.zeros((5, 5), dtype=np.complex)
+    tmp = np.zeros((5, 5), dtype=complex)
     tmp[0, 0] = 9/35*ten_dq - 2*ds  # d3z2-r2
     tmp[1, 1] = -6/35*ten_dq - ds  # dzx
     tmp[2, 2] = -6/35*ten_dq - ds  # dzy
     tmp[3, 3] = 19/35*ten_dq + 2*ds  # dx2-y2
     tmp[4, 4] = -16/35*ten_dq + 2*ds  # dxy
 
-    cf = np.zeros((10, 10), dtype=np.complex)
+    cf = np.zeros((10, 10), dtype=complex)
     cf[0:10:2, 0:10:2] = tmp
     cf[1:10:2, 1:10:2] = tmp
 
@@ -753,12 +753,12 @@ def cf_tetragonal_t2g(ten_dq, d1, d3):
     ds = (d3 + d1) / 7.0
     dq = ten_dq / 10.0
 
-    tmp = np.zeros((3, 3), dtype=np.complex)
+    tmp = np.zeros((3, 3), dtype=complex)
     tmp[0, 0] = -4 * dq - 1 * ds + 4 * dt  # dxz
     tmp[1, 1] = -4 * dq - 1 * ds + 4 * dt  # dyz
     tmp[2, 2] = -4 * dq + 2 * ds - 1 * dt  # dxy
 
-    cf = np.zeros((6, 6), dtype=np.complex)
+    cf = np.zeros((6, 6), dtype=complex)
     cf[0:6:2, 0:6:2] += tmp
     cf[1:6:2, 1:6:2] += tmp
     cf[:, :] = cb_op(cf, tmat_r2c('t2g', True))

--- a/edrixs/coulomb_utensor.py
+++ b/edrixs/coulomb_utensor.py
@@ -548,7 +548,7 @@ def get_umat_slater(case, *args):
                 tmat = tmat_c2j(orbl)
             umat = transform_utensor(umat, tmat)
             indx = orb_indx[shells[0]]
-            umat_tmp = np.zeros((len(indx), len(indx), len(indx), len(indx)), dtype=np.complex)
+            umat_tmp = np.zeros((len(indx), len(indx), len(indx), len(indx)), dtype=complex)
             umat_tmp[:, :, :, :] = umat[indx][:, indx][:, :, indx][:, :, :, indx]
             if shells[0] == 't2g':
                 umat_tmp[:, :, :, :] = transform_utensor(umat_tmp, tmat_r2c('t2g', True))
@@ -579,7 +579,7 @@ def get_umat_slater(case, *args):
         umat = umat_slater(l_list, fk)
         # truncate to a sub-shell if necessary
         if (name1 in special_shell) or (name2 in special_shell):
-            tmat = np.eye(ntot, dtype=np.complex)
+            tmat = np.eye(ntot, dtype=complex)
             indx1 = list(range(0, n1))
             if name1 in special_shell:
                 if name1 == 't2g':
@@ -598,7 +598,7 @@ def get_umat_slater(case, *args):
 
             indx = indx1 + indx2
             umat = transform_utensor(umat, tmat)
-            umat_tmp = np.zeros((len(indx), len(indx), len(indx), len(indx)), dtype=np.complex)
+            umat_tmp = np.zeros((len(indx), len(indx), len(indx), len(indx)), dtype=complex)
             umat_tmp[:, :, :, :] = umat[indx][:, indx][:, :, indx][:, :, :, indx]
             if name1 == 't2g' or name2 == 't2g':
                 tmat = np.eye(len(indx), dtype=np.complex128)
@@ -675,7 +675,7 @@ def get_umat_slater_3shells(shell_name, *args):
     if it != len(args):
         raise Exception("Number of Slater integrals", len(args), " is not equal to ", it)
 
-    umat = np.zeros((ntot, ntot, ntot, ntot), dtype=np.complex)
+    umat = np.zeros((ntot, ntot, ntot, ntot), dtype=complex)
 
     # v1-v2
     case = v1_name + v2_name

--- a/edrixs/iostream.py
+++ b/edrixs/iostream.py
@@ -9,7 +9,7 @@ def write_tensor_1(tensor, fname, only_nonzeros=False, tol=1E-10, fmt_int='{:10d
                    fmt_float='{:.15f}'):
     (n1, ) = tensor.shape
     is_cmplx = False
-    if tensor.dtype == np.complex or tensor.dtype == np.complex128:
+    if tensor.dtype == complex or tensor.dtype == np.complex128:
         is_cmplx = True
     space = "    "
     f = open(fname, 'w')
@@ -29,7 +29,7 @@ def write_tensor_2(tensor, fname, only_nonzeros=False, tol=1E-10, fmt_int='{:10d
                    fmt_float='{:.15f}'):
     (n1, n2) = tensor.shape
     is_cmplx = False
-    if tensor.dtype == np.complex or tensor.dtype == np.complex128:
+    if tensor.dtype == complex or tensor.dtype == np.complex128:
         is_cmplx = True
     space = "    "
     f = open(fname, 'w')
@@ -50,7 +50,7 @@ def write_tensor_3(tensor, fname, only_nonzeros=False, tol=1E-10, fmt_int='{:10d
                    fmt_float='{:.15f}'):
     (n1, n2, n3) = tensor.shape
     is_cmplx = False
-    if tensor.dtype == np.complex or tensor.dtype == np.complex128:
+    if tensor.dtype == complex or tensor.dtype == np.complex128:
         is_cmplx = True
     space = "    "
     f = open(fname, 'w')
@@ -73,7 +73,7 @@ def write_tensor_4(tensor, fname, only_nonzeros=False, tol=1E-10, fmt_int='{:10d
                    fmt_float='{:.15f}'):
     (n1, n2, n3, n4) = tensor.shape
     is_cmplx = False
-    if tensor.dtype == np.complex or tensor.dtype == np.complex128:
+    if tensor.dtype == complex or tensor.dtype == np.complex128:
         is_cmplx = True
     space = "    "
     f = open(fname, 'w')
@@ -97,7 +97,7 @@ def write_tensor_5(tensor, fname, only_nonzeros=False, tol=1E-10, fmt_int='{:10d
                    fmt_float='{:.15f}'):
     (n1, n2, n3, n4, n5) = tensor.shape
     is_cmplx = False
-    if tensor.dtype == np.complex or tensor.dtype == np.complex128:
+    if tensor.dtype == complex or tensor.dtype == np.complex128:
         is_cmplx = True
     space = "    "
     f = open(fname, 'w')

--- a/edrixs/iostream.py
+++ b/edrixs/iostream.py
@@ -9,7 +9,7 @@ def write_tensor_1(tensor, fname, only_nonzeros=False, tol=1E-10, fmt_int='{:10d
                    fmt_float='{:.15f}'):
     (n1, ) = tensor.shape
     is_cmplx = False
-    if tensor.dtype == complex or tensor.dtype == np.complex128:
+    if tensor.dtype in (complex, np.complex128):
         is_cmplx = True
     space = "    "
     f = open(fname, 'w')
@@ -29,7 +29,7 @@ def write_tensor_2(tensor, fname, only_nonzeros=False, tol=1E-10, fmt_int='{:10d
                    fmt_float='{:.15f}'):
     (n1, n2) = tensor.shape
     is_cmplx = False
-    if tensor.dtype == complex or tensor.dtype == np.complex128:
+    if tensor.dtype in (complex, np.complex128):
         is_cmplx = True
     space = "    "
     f = open(fname, 'w')
@@ -50,7 +50,7 @@ def write_tensor_3(tensor, fname, only_nonzeros=False, tol=1E-10, fmt_int='{:10d
                    fmt_float='{:.15f}'):
     (n1, n2, n3) = tensor.shape
     is_cmplx = False
-    if tensor.dtype == complex or tensor.dtype == np.complex128:
+    if tensor.dtype in (complex, np.complex128):
         is_cmplx = True
     space = "    "
     f = open(fname, 'w')
@@ -73,7 +73,7 @@ def write_tensor_4(tensor, fname, only_nonzeros=False, tol=1E-10, fmt_int='{:10d
                    fmt_float='{:.15f}'):
     (n1, n2, n3, n4) = tensor.shape
     is_cmplx = False
-    if tensor.dtype == complex or tensor.dtype == np.complex128:
+    if tensor.dtype in (complex, np.complex128):
         is_cmplx = True
     space = "    "
     f = open(fname, 'w')
@@ -97,7 +97,7 @@ def write_tensor_5(tensor, fname, only_nonzeros=False, tol=1E-10, fmt_int='{:10d
                    fmt_float='{:.15f}'):
     (n1, n2, n3, n4, n5) = tensor.shape
     is_cmplx = False
-    if tensor.dtype == complex or tensor.dtype == np.complex128:
+    if tensor.dtype in (complex, np.complex128):
         is_cmplx = True
     space = "    "
     f = open(fname, 'w')

--- a/edrixs/manybody_operator.py
+++ b/edrixs/manybody_operator.py
@@ -249,7 +249,7 @@ def build_opers(nfermion, coeff, lb, rb=None, tol=1E-10):
             hmat = two_fermion(coeff, lb, rb, tol)
         else:
             tot = np.prod(dim[0:-2])
-            hmat_tmp = np.zeros((tot, nl, nr), dtype=np.complex)
+            hmat_tmp = np.zeros((tot, nl, nr), dtype=complex)
             coeff_tmp = coeff.reshape((tot, dim[-2], dim[-1]))
             for i in range(tot):
                 hmat_tmp[i] = two_fermion(coeff_tmp[i], lb, rb, tol)
@@ -262,7 +262,7 @@ def build_opers(nfermion, coeff, lb, rb=None, tol=1E-10):
             hmat = four_fermion(coeff, lb, rb, tol)
         else:
             tot = np.prod(dim[0:-4])
-            hmat_tmp = np.zeros((tot, nl, nr), dtype=np.complex)
+            hmat_tmp = np.zeros((tot, nl, nr), dtype=complex)
             coeff_tmp = coeff.reshape((tot, dim[-4], dim[-3], dim[-2], dim[-1]))
             for i in range(tot):
                 hmat_tmp[i] = four_fermion(coeff_tmp[i], lb, rb, tol)

--- a/edrixs/photon_transition.py
+++ b/edrixs/photon_transition.py
@@ -154,8 +154,8 @@ def get_trans_oper(case):
         special_shell[5]: [0, 1, 2, 3, 4, 5],
         special_shell[6]: [6, 7, 8, 9, 10, 11, 12, 13]
     }
-    left_tmat = np.eye(v_norb, dtype=np.complex)
-    right_tmat = np.eye(c_norb, dtype=np.complex)
+    left_tmat = np.eye(v_norb, dtype=complex)
+    right_tmat = np.eye(c_norb, dtype=complex)
     indx1 = list(range(0, v_norb))
     indx2 = list(range(0, c_norb))
     if v_name in special_shell:
@@ -173,7 +173,7 @@ def get_trans_oper(case):
     else:
         npol = 3
 
-    op_tmp = np.zeros((npol, len(indx1), len(indx2)), dtype=np.complex)
+    op_tmp = np.zeros((npol, len(indx1), len(indx2)), dtype=complex)
     for i in range(npol):
         op[i] = cb_op2(op[i], left_tmat, right_tmat)
         op_tmp[i] = op[i, indx1][:, indx2]
@@ -544,7 +544,7 @@ def quadrupole_polvec(polvec, wavevec):
         Quadrupolar polarization vector.
     """
 
-    quad_vec = np.zeros(5, dtype=np.complex)
+    quad_vec = np.zeros(5, dtype=complex)
     kvec = wavevec / np.sqrt(np.dot(wavevec, wavevec))
 
     quad_vec[0] = 0.5 * (2 * polvec[2] * kvec[2] - polvec[0] * kvec[0] - polvec[1] * kvec[1])

--- a/edrixs/plot_spectrum.py
+++ b/edrixs/plot_spectrum.py
@@ -43,7 +43,7 @@ def get_spectra_from_poles(poles_dict, omega_mesh, gamma_mesh, temperature):
     gs_dist = boltz_dist(poles_dict['eigval'], temperature)
     ngs = len(poles_dict['eigval'])
     for i in range(ngs):
-        tmp_vec = np.zeros(nom, dtype=np.complex)
+        tmp_vec = np.zeros(nom, dtype=complex)
         neff = poles_dict['npoles'][i]
         alpha = poles_dict['alpha'][i]
         beta = poles_dict['beta'][i]

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -141,16 +141,16 @@ def ed_1v1c_py(shell_name, *, shell_level=None, v_soc=None, c_soc=0,
     # total number of orbitals
     ntot = v_norb + c_norb
 
-    emat_i = np.zeros((ntot, ntot), dtype=np.complex)
-    emat_n = np.zeros((ntot, ntot), dtype=np.complex)
+    emat_i = np.zeros((ntot, ntot), dtype=complex)
+    emat_n = np.zeros((ntot, ntot), dtype=complex)
 
     # Coulomb interaction
     # Get the names of all the required slater integrals
     slater_name = slater_integrals_name((v_name, c_name), ('v', 'c'))
     nslat = len(slater_name)
 
-    slater_i = np.zeros(nslat, dtype=np.float)
-    slater_n = np.zeros(nslat, dtype=np.float)
+    slater_i = np.zeros(nslat, dtype=float)
+    slater_n = np.zeros(nslat, dtype=float)
 
     if slater is not None:
         if nslat > len(slater[0]):
@@ -239,8 +239,8 @@ def ed_1v1c_py(shell_name, *, shell_level=None, v_soc=None, c_soc=0,
 
     # Build many-body Hamiltonian in Fock basis
     print("edrixs >>> Building Many-body Hamiltonians ...")
-    hmat_i = np.zeros((ncfg_i, ncfg_i), dtype=np.complex)
-    hmat_n = np.zeros((ncfg_n, ncfg_n), dtype=np.complex)
+    hmat_i = np.zeros((ncfg_i, ncfg_i), dtype=complex)
+    hmat_n = np.zeros((ncfg_n, ncfg_n), dtype=complex)
     hmat_i[:, :] += two_fermion(emat_i, basis_i, basis_i)
     hmat_i[:, :] += four_fermion(umat_i, basis_i)
     hmat_n[:, :] += two_fermion(emat_n, basis_n, basis_n)
@@ -264,7 +264,7 @@ def ed_1v1c_py(shell_name, *, shell_level=None, v_soc=None, c_soc=0,
         local_axis = np.eye(3)
     tmp = get_trans_oper(case)
     npol, n, m = tmp.shape
-    tmp_g = np.zeros((npol, n, m), dtype=np.complex)
+    tmp_g = np.zeros((npol, n, m), dtype=complex)
     # Transform the transition operators to global-xyz axis
     # dipolar transition
     if npol == 3:
@@ -283,8 +283,8 @@ def ed_1v1c_py(shell_name, *, shell_level=None, v_soc=None, c_soc=0,
     else:
         raise Exception("Have NOT implemented this case: ", npol)
 
-    tmp2 = np.zeros((npol, ntot, ntot), dtype=np.complex)
-    trans_op = np.zeros((npol, ncfg_n, ncfg_i), dtype=np.complex)
+    tmp2 = np.zeros((npol, ntot, ntot), dtype=complex)
+    trans_op = np.zeros((npol, ncfg_n, ncfg_i), dtype=complex)
     for i in range(npol):
         tmp2[i, 0:v_norb, v_norb:ntot] = tmp_g[i]
         trans_op[i] = two_fermion(tmp2[i], basis_n, basis_i)
@@ -372,8 +372,8 @@ def xas_1v1c_py(eval_i, eval_n, trans_op, ominc, *, gamma_c=0.1, thin=1.0, phi=0
     else:
         scatter_axis = np.array(scatter_axis)
 
-    xas = np.zeros((n_om, len(pol_type)), dtype=np.float)
-    gamma_core = np.zeros(n_om, dtype=np.float)
+    xas = np.zeros((n_om, len(pol_type)), dtype=float)
+    gamma_core = np.zeros(n_om, dtype=float)
     prob = boltz_dist([eval_i[i] for i in gs_list], temperature)
     if np.isscalar(gamma_c):
         gamma_core[:] = np.ones(n_om) * gamma_c
@@ -385,7 +385,7 @@ def xas_1v1c_py(eval_i, eval_n, trans_op, ominc, *, gamma_c=0.1, thin=1.0, phi=0
         for it, (pt, alpha) in enumerate(pol_type):
             if pt.strip() not in ['left', 'right', 'linear', 'isotropic']:
                 raise Exception("Unknown polarization type: ", pt)
-            polvec = np.zeros(npol, dtype=np.complex)
+            polvec = np.zeros(npol, dtype=complex)
             if pt.strip() == 'left' or pt.strip() == 'right' or pt.strip() == 'linear':
                 pol = dipole_polvec_xas(thin, phi, alpha, scatter_axis, pt)
                 if npol == 3:  # dipolar transition
@@ -404,7 +404,7 @@ def xas_1v1c_py(eval_i, eval_n, trans_op, ominc, *, gamma_c=0.1, thin=1.0, phi=0
                         )
                     xas[i, it] = xas[i, it] / npol
                 else:
-                    F_mag = np.zeros(ncfg_n, dtype=np.complex)
+                    F_mag = np.zeros(ncfg_n, dtype=complex)
                     for k in range(npol):
                         F_mag += trans_op[k, :, igs] * polvec[k]
                     xas[i, it] += (
@@ -489,8 +489,8 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
     print("edrixs >>> Running RIXS ... ")
     n_ominc = len(ominc)
     n_eloss = len(eloss)
-    gamma_core = np.zeros(n_ominc, dtype=np.float)
-    gamma_final = np.zeros(n_eloss, dtype=np.float)
+    gamma_core = np.zeros(n_ominc, dtype=float)
+    gamma_final = np.zeros(n_eloss, dtype=float)
     if np.isscalar(gamma_c):
         gamma_core[:] = np.ones(n_ominc) * gamma_c
     else:
@@ -511,13 +511,13 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
         scatter_axis = np.array(scatter_axis)
 
     prob = boltz_dist([eval_i[i] for i in gs_list], temperature)
-    rixs = np.zeros((len(ominc), len(eloss), len(pol_type)), dtype=np.float)
+    rixs = np.zeros((len(ominc), len(eloss), len(pol_type)), dtype=float)
     npol, n, m = trans_op.shape
     trans_emi = np.zeros((npol, m, n), dtype=np.complex128)
     for i in range(npol):
         trans_emi[i] = np.conj(np.transpose(trans_op[i]))
-    polvec_i = np.zeros(npol, dtype=np.complex)
-    polvec_f = np.zeros(npol, dtype=np.complex)
+    polvec_i = np.zeros(npol, dtype=complex)
+    polvec_f = np.zeros(npol, dtype=complex)
 
     # Calculate RIXS
     for i, om in enumerate(ominc):
@@ -539,7 +539,7 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
             else:
                 raise Exception("Have NOT implemented this type of transition operators")
             # scattering magnitude with polarization vectors
-            F_mag = np.zeros((len(eval_i), len(gs_list)), dtype=np.complex)
+            F_mag = np.zeros((len(eval_i), len(gs_list)), dtype=complex)
             for m in range(npol):
                 for n in range(npol):
                     F_mag[:, :] += np.conj(polvec_f[m]) * F_fi[m, n] * polvec_i[n]
@@ -922,8 +922,8 @@ def _ed_1or2_valence_1core(
     else:
         slater_name = slater_integrals_name((v1_name, v2_name, c_name), ('v1', 'v2', 'c1'))
     nslat = len(slater_name)
-    slater_i = np.zeros(nslat, dtype=np.float)
-    slater_n = np.zeros(nslat, dtype=np.float)
+    slater_i = np.zeros(nslat, dtype=float)
+    slater_n = np.zeros(nslat, dtype=float)
 
     if slater is not None:
         if nslat > len(slater[0]):
@@ -959,8 +959,8 @@ def _ed_1or2_valence_1core(
         write_umat(umat_i, 'coulomb_i.in')
         write_umat(umat_n, 'coulomb_n.in')
 
-    emat_i = np.zeros((ntot, ntot), dtype=np.complex)
-    emat_n = np.zeros((ntot, ntot), dtype=np.complex)
+    emat_i = np.zeros((ntot, ntot), dtype=complex)
+    emat_n = np.zeros((ntot, ntot), dtype=complex)
     # SOC
     if v1_soc is not None and v1_name in ['p', 'd', 't2g', 'f']:
         emat_i[0:v1_norb, 0:v1_norb] += atom_hsoc(v1_name, v1_soc[0])
@@ -1055,7 +1055,7 @@ def _ed_1or2_valence_1core(
 
         # read eigvals.dat and denmat.dat
         data = np.loadtxt('eigvals.dat', ndmin=2)
-        eval_i = np.zeros(neval, dtype=np.float)
+        eval_i = np.zeros(neval, dtype=float)
         eval_i[0:neval] = data[0:neval, 1]
         data = np.loadtxt('denmat.dat', ndmin=2)
         tmp = (nvector, v1v2_norb, v1v2_norb)
@@ -1336,8 +1336,8 @@ def _xas_1or2_valence_1core(
         raise Exception('Unkonwn trans_to_which: ', trans_to_which)
     tmp = get_trans_oper(case)
     npol, n, m = tmp.shape
-    tmp_g = np.zeros((npol, n, m), dtype=np.complex)
-    trans_mat = np.zeros((npol, ntot, ntot), dtype=np.complex)
+    tmp_g = np.zeros((npol, n, m), dtype=complex)
+    trans_mat = np.zeros((npol, ntot, ntot), dtype=complex)
     # Transform the transition operators to global-xyz axis
     # dipolar transition
     if npol == 3:
@@ -1360,14 +1360,14 @@ def _xas_1or2_valence_1core(
         trans_mat[:, v1_norb:v1v2_norb, v1v2_norb:ntot] = tmp_g
 
     n_om = len(ominc)
-    gamma_core = np.zeros(n_om, dtype=np.float)
+    gamma_core = np.zeros(n_om, dtype=float)
     if np.isscalar(gamma_c):
         gamma_core[:] = np.ones(n_om) * gamma_c
     else:
         gamma_core[:] = gamma_c
 
     # loop over different polarization
-    xas = np.zeros((n_om, len(pol_type)), dtype=np.float)
+    xas = np.zeros((n_om, len(pol_type)), dtype=float)
     poles = []
     comm.Barrier()
     for it, (pt, alpha) in enumerate(pol_type):
@@ -1375,13 +1375,13 @@ def _xas_1or2_valence_1core(
             if rank == 0:
                 print("edrixs >>> Loop over for polarization: ", it, pt, flush=True)
                 kvec = unit_wavevector(thin, phi, scatter_axis, 'in')
-                polvec = np.zeros(npol, dtype=np.complex)
+                polvec = np.zeros(npol, dtype=complex)
                 pol = dipole_polvec_xas(thin, phi, alpha, scatter_axis, pt)
                 if npol == 3:  # Dipolar transition
                     polvec[:] = pol
                 if npol == 5:  # Quadrupolar transition
                     polvec[:] = quadrupole_polvec(pol, kvec)
-                trans = np.zeros((ntot, ntot), dtype=np.complex)
+                trans = np.zeros((ntot, ntot), dtype=complex)
                 for i in range(npol):
                     trans[:, :] += trans_mat[i] * polvec[i]
                 write_emat(trans, 'transop_xas.in')
@@ -1705,8 +1705,8 @@ def _rixs_1or2_valence_1core(
             raise Exception('Unkonwn trans_to_which: ', trans_to_which)
         tmp = get_trans_oper(case)
         npol, n, m = tmp.shape
-        tmp_g = np.zeros((npol, n, m), dtype=np.complex)
-        trans_mat = np.zeros((npol, ntot, ntot), dtype=np.complex)
+        tmp_g = np.zeros((npol, n, m), dtype=complex)
+        trans_mat = np.zeros((npol, ntot, ntot), dtype=complex)
         # Transform the transition operators to global-xyz axis
         # dipolar transition
         if npol == 3:
@@ -1730,19 +1730,19 @@ def _rixs_1or2_valence_1core(
 
     n_om = len(ominc)
     neloss = len(eloss)
-    gamma_core = np.zeros(n_om, dtype=np.float)
+    gamma_core = np.zeros(n_om, dtype=float)
     if np.isscalar(gamma_c):
         gamma_core[:] = np.ones(n_om) * gamma_c
     else:
         gamma_core[:] = gamma_c
-    gamma_final = np.zeros(neloss, dtype=np.float)
+    gamma_final = np.zeros(neloss, dtype=float)
     if np.isscalar(gamma_f):
         gamma_final[:] = np.ones(neloss) * gamma_f
     else:
         gamma_final[:] = gamma_f
 
     # loop over different polarization
-    rixs = np.zeros((n_om, neloss, len(pol_type)), dtype=np.float)
+    rixs = np.zeros((n_om, neloss, len(pol_type)), dtype=float)
     poles = []
     comm.Barrier()
     # loop over different polarization
@@ -1761,8 +1761,8 @@ def _rixs_1or2_valence_1core(
                 print(flush=True)
                 print("edrixs >>> Calculate RIXS for incident energy: ", omega, flush=True)
                 print("edrixs >>> Polarization: ", ip, flush=True)
-                polvec_i = np.zeros(npol, dtype=np.complex)
-                polvec_f = np.zeros(npol, dtype=np.complex)
+                polvec_i = np.zeros(npol, dtype=complex)
+                polvec_f = np.zeros(npol, dtype=complex)
                 ei, ef = dipole_polvec_rixs(thin, thout, phi, alpha, beta,
                                             scatter_axis, (it, jt))
                 # dipolar transition
@@ -1777,8 +1777,8 @@ def _rixs_1or2_valence_1core(
                     polvec_f[:] = quadrupole_polvec(ef, kf)
                 else:
                     raise Exception("Have NOT implemented this type of transition operators")
-                trans_i = np.zeros((ntot, ntot), dtype=np.complex)
-                trans_f = np.zeros((ntot, ntot), dtype=np.complex)
+                trans_i = np.zeros((ntot, ntot), dtype=complex)
+                trans_f = np.zeros((ntot, ntot), dtype=complex)
                 for i in range(npol):
                     trans_i[:, :] += trans_mat[i] * polvec_i[i]
                 write_emat(trans_i, 'transop_rixs_i.in')
@@ -1969,8 +1969,8 @@ def ed_siam_fort(comm, shell_name, nbath, *, siam_type=0, v_noccu=1, static_core
 
     slater_name = slater_integrals_name((v_name, c_name), ('v', 'c'))
     nslat = len(slater_name)
-    slater_i = np.zeros(nslat, dtype=np.float)
-    slater_n = np.zeros(nslat, dtype=np.float)
+    slater_i = np.zeros(nslat, dtype=float)
+    slater_n = np.zeros(nslat, dtype=float)
 
     if slater is not None:
         if nslat > len(slater[0]):
@@ -1998,8 +1998,8 @@ def ed_siam_fort(comm, shell_name, nbath, *, siam_type=0, v_noccu=1, static_core
     umat_tmp_i = get_umat_slater(v_name + c_name, *slater_i)
     umat_tmp_n = get_umat_slater(v_name + c_name, *slater_n)
 
-    umat_i = np.zeros((ntot, ntot, ntot, ntot), dtype=np.complex)
-    umat_n = np.zeros((ntot, ntot, ntot, ntot), dtype=np.complex)
+    umat_i = np.zeros((ntot, ntot, ntot, ntot), dtype=complex)
+    umat_n = np.zeros((ntot, ntot, ntot, ntot), dtype=complex)
 
     indx = list(range(0, v_norb)) + [ntot_v + i for i in range(0, c_norb)]
     for i in range(v_norb+c_norb):
@@ -2012,8 +2012,8 @@ def ed_siam_fort(comm, shell_name, nbath, *, siam_type=0, v_noccu=1, static_core
         write_umat(umat_i, 'coulomb_i.in')
         write_umat(umat_n, 'coulomb_n.in')
 
-    emat_i = np.zeros((ntot, ntot), dtype=np.complex)
-    emat_n = np.zeros((ntot, ntot), dtype=np.complex)
+    emat_i = np.zeros((ntot, ntot), dtype=complex)
+    emat_n = np.zeros((ntot, ntot), dtype=complex)
     # General hybridization function, including off-diagonal terms
     if siam_type == 1:
         if hopping is not None:
@@ -2075,11 +2075,11 @@ def ed_siam_fort(comm, shell_name, nbath, *, siam_type=0, v_noccu=1, static_core
     emat_n[0:v_norb, 0:v_norb] -= np.eye(v_norb) * static_core_pot
 
     if trans_c2n is None:
-        trans_c2n = np.eye(v_norb, dtype=np.complex)
+        trans_c2n = np.eye(v_norb, dtype=complex)
     else:
         trans_c2n = np.array(trans_c2n)
 
-    tmat = np.eye(ntot, dtype=np.complex)
+    tmat = np.eye(ntot, dtype=complex)
     for i in range(nbath+1):
         off = i * v_norb
         tmat[off:off+v_norb, off:off+v_norb] = np.conj(np.transpose(trans_c2n))
@@ -2127,7 +2127,7 @@ def ed_siam_fort(comm, shell_name, nbath, *, siam_type=0, v_noccu=1, static_core
             ed_fsolver(fcomm, rank, size)
             comm.Barrier()
             data = np.loadtxt('eigvals.dat', ndmin=2)
-            eval_i = np.zeros(neval, dtype=np.float)
+            eval_i = np.zeros(neval, dtype=float)
             eval_i[0:neval] = data[0:neval, 1]
             data = np.loadtxt('denmat.dat', ndmin=2)
             tmp = (nvector, ntot_v, ntot_v)
@@ -2241,7 +2241,7 @@ def ed_siam_fort(comm, shell_name, nbath, *, siam_type=0, v_noccu=1, static_core
         ed_fsolver(fcomm, rank, size)
         comm.Barrier()
         data = np.loadtxt('eigvals.dat', ndmin=2)
-        eval_i = np.zeros(neval, dtype=np.float)
+        eval_i = np.zeros(neval, dtype=float)
         eval_i[0:neval] = data[0:neval, 1]
         data = np.loadtxt('denmat.dat', ndmin=2)
         tmp = (nvector, ntot_v, ntot_v)
@@ -2379,8 +2379,8 @@ def xas_siam_fort(comm, shell_name, nbath, ominc, *, gamma_c=0.1,
     case = v_name + c_name
     tmp = get_trans_oper(case)
     npol, n, m = tmp.shape
-    tmp_g = np.zeros((npol, n, m), dtype=np.complex)
-    trans_mat = np.zeros((npol, ntot, ntot), dtype=np.complex)
+    tmp_g = np.zeros((npol, n, m), dtype=complex)
+    trans_mat = np.zeros((npol, ntot, ntot), dtype=complex)
     # Transform the transition operators to global-xyz axis
     # dipolar transition
     if npol == 3:
@@ -2400,14 +2400,14 @@ def xas_siam_fort(comm, shell_name, nbath, ominc, *, gamma_c=0.1,
     trans_mat[:, 0:v_norb, ntot_v:ntot] = tmp_g
 
     n_om = len(ominc)
-    gamma_core = np.zeros(n_om, dtype=np.float)
+    gamma_core = np.zeros(n_om, dtype=float)
     if np.isscalar(gamma_c):
         gamma_core[:] = np.ones(n_om) * gamma_c
     else:
         gamma_core[:] = gamma_c
 
     # loop over different polarization
-    xas = np.zeros((n_om, len(pol_type)), dtype=np.float)
+    xas = np.zeros((n_om, len(pol_type)), dtype=float)
     poles = []
     comm.Barrier()
     for it, (pt, alpha) in enumerate(pol_type):
@@ -2415,14 +2415,14 @@ def xas_siam_fort(comm, shell_name, nbath, ominc, *, gamma_c=0.1,
             if rank == 0:
                 print("edrixs >>> Loop over for polarization: ", it, pt, flush=True)
                 kvec = unit_wavevector(thin, phi, scatter_axis, 'in')
-                polvec = np.zeros(npol, dtype=np.complex)
+                polvec = np.zeros(npol, dtype=complex)
                 pol = dipole_polvec_xas(thin, phi, alpha, scatter_axis, pt)
                 if npol == 3:  # Dipolar transition
                     polvec[:] = pol
                 if npol == 5:  # Quadrupolar transition
                     polvec[:] = quadrupole_polvec(pol, kvec)
 
-                trans = np.zeros((ntot, ntot), dtype=np.complex)
+                trans = np.zeros((ntot, ntot), dtype=complex)
                 for i in range(npol):
                     trans[:, :] += trans_mat[i] * polvec[i]
                 write_emat(trans, 'transop_xas.in')
@@ -2596,8 +2596,8 @@ def rixs_siam_fort(comm, shell_name, nbath, ominc, eloss, *, gamma_c=0.1, gamma_
         case = v_name + c_name
         tmp = get_trans_oper(case)
         npol, n, m = tmp.shape
-        tmp_g = np.zeros((npol, n, m), dtype=np.complex)
-        trans_mat = np.zeros((npol, ntot, ntot), dtype=np.complex)
+        tmp_g = np.zeros((npol, n, m), dtype=complex)
+        trans_mat = np.zeros((npol, ntot, ntot), dtype=complex)
         # Transform the transition operators to global-xyz axis
         # dipolar transition
         if npol == 3:
@@ -2618,19 +2618,19 @@ def rixs_siam_fort(comm, shell_name, nbath, ominc, eloss, *, gamma_c=0.1, gamma_
 
     n_om = len(ominc)
     neloss = len(eloss)
-    gamma_core = np.zeros(n_om, dtype=np.float)
+    gamma_core = np.zeros(n_om, dtype=float)
     if np.isscalar(gamma_c):
         gamma_core[:] = np.ones(n_om) * gamma_c
     else:
         gamma_core[:] = gamma_c
-    gamma_final = np.zeros(neloss, dtype=np.float)
+    gamma_final = np.zeros(neloss, dtype=float)
     if np.isscalar(gamma_f):
         gamma_final[:] = np.ones(neloss) * gamma_f
     else:
         gamma_final[:] = gamma_f
 
     # loop over different polarization
-    rixs = np.zeros((n_om, neloss, len(pol_type)), dtype=np.float)
+    rixs = np.zeros((n_om, neloss, len(pol_type)), dtype=float)
     poles = []
     comm.Barrier()
     # loop over different polarization
@@ -2649,8 +2649,8 @@ def rixs_siam_fort(comm, shell_name, nbath, ominc, eloss, *, gamma_c=0.1, gamma_
                 print(flush=True)
                 print("edrixs >>> Calculate RIXS for incident energy: ", omega, flush=True)
                 print("edrixs >>> Polarization: ", ip, flush=True)
-                polvec_i = np.zeros(npol, dtype=np.complex)
-                polvec_f = np.zeros(npol, dtype=np.complex)
+                polvec_i = np.zeros(npol, dtype=complex)
+                polvec_f = np.zeros(npol, dtype=complex)
                 ei, ef = dipole_polvec_rixs(thin, thout, phi, alpha, beta,
                                             scatter_axis, (it, jt))
                 # dipolar transition
@@ -2665,8 +2665,8 @@ def rixs_siam_fort(comm, shell_name, nbath, ominc, eloss, *, gamma_c=0.1, gamma_
                     polvec_f[:] = quadrupole_polvec(ef, kf)
                 else:
                     raise Exception("Have NOT implemented this type of transition operators")
-                trans_i = np.zeros((ntot, ntot), dtype=np.complex)
-                trans_f = np.zeros((ntot, ntot), dtype=np.complex)
+                trans_i = np.zeros((ntot, ntot), dtype=complex)
+                trans_f = np.zeros((ntot, ntot), dtype=complex)
                 for i in range(npol):
                     trans_i[:, :] += trans_mat[i] * polvec_i[i]
                 write_emat(trans_i, 'transop_rixs_i.in')

--- a/edrixs/wannier_ham.py
+++ b/edrixs/wannier_ham.py
@@ -58,9 +58,9 @@ class HR():
             for i in range(nline):
                 tmp.extend(f.readline().strip().split())
             tmp = [np.int(item) for item in tmp]
-            deg_rpt = np.array(tmp, dtype=np.int)
+            deg_rpt = np.array(tmp, dtype=int)
             # read hr for each r-point
-            rpts = np.zeros((nrpt, 3), dtype=np.int)
+            rpts = np.zeros((nrpt, 3), dtype=int)
             hr = np.zeros((nrpt, nwann, nwann), dtype=np.complex128)
             for i in range(nrpt):
                 for j in range(nwann):

--- a/examples/cpc/anderson_impurity/get_inputs.py
+++ b/examples/cpc/anderson_impurity/get_inputs.py
@@ -77,7 +77,7 @@ def get_hopping_coulomb():
     umat_tmp[:, :, :, :] = edrixs.transform_utensor(umat_tmp, tmat)
     id1 = [0, 1, 2, 3, 4, 5, 8, 9, 10, 11]
     id2 = [0, 1, 2, 3, 4, 5, 24, 25, 26, 27]
-    umat_n = np.zeros((norbs, norbs, norbs, norbs), dtype=np.complex)
+    umat_n = np.zeros((norbs, norbs, norbs, norbs), dtype=complex)
     for i in range(10):
         for j in range(10):
             for k in range(10):
@@ -93,7 +93,7 @@ def get_hopping_coulomb():
     e1, v1 = data[:, 0], data[:, 1]
     e2, v2 = data[:, 2], data[:, 3]
 
-    h = np.zeros((24, 24), dtype=np.complex)
+    h = np.zeros((24, 24), dtype=complex)
     h[0, 0] = h[1, 1] = -14.7627972353
     h[2, 2] = h[3, 3] = h[4, 4] = h[5, 5] = -15.4689430453
     for i in range(N_site):
@@ -141,7 +141,7 @@ def get_hopping_coulomb():
 
 def get_transop():
     tmp = edrixs.get_trans_oper('t2gp')
-    dipole = np.zeros((3, 28, 28), dtype=np.complex)
+    dipole = np.zeros((3, 28, 28), dtype=complex)
     for i in range(3):
         tmp[i] = edrixs.cb_op2(tmp[i], edrixs.tmat_c2j(1), edrixs.tmat_c2j(1))
         dipole[i, 0:6, 24:28] = tmp[i, 0:6, 2:6]

--- a/examples/cpc/single_atom/hellorixs.py
+++ b/examples/cpc/single_atom/hellorixs.py
@@ -6,8 +6,7 @@ from matplotlib.ticker import MultipleLocator
 
 import edrixs
 
-font = {'family': 'Times New Roman',
-        'weight': 'medium',
+font = {'weight': 'medium',
         'size': '18'}
 plt.rc('font', **font)
 
@@ -16,8 +15,8 @@ def ed():
     # 1-10: Ni-3d valence orbitals, 11-16: Ni-2p core orbitals
     # Single particle basis: complex shperical Harmonics
     ndorb, nporb, ntot = 10, 6, 16
-    emat_i = np.zeros((ntot, ntot), dtype=np.complex)
-    emat_n = np.zeros((ntot, ntot), dtype=np.complex)
+    emat_i = np.zeros((ntot, ntot), dtype=complex)
+    emat_n = np.zeros((ntot, ntot), dtype=complex)
 
     # 4-index Coulomb interaction tensor, parameterized by
     # Slater integrals, which are obtained from Cowan's code
@@ -44,7 +43,7 @@ def ed():
     # which are first defined in the real cubic Harmonics basis,
     # and then transformed to complex shperical Harmonics basis.
     dt, ds, dq = 0.011428, 0.035714, 0.13
-    tmp = np.zeros((5, 5), dtype=np.complex)
+    tmp = np.zeros((5, 5), dtype=complex)
     tmp[0, 0] = 6 * dq - 2 * ds - 6 * dt   # d3z2-r2
     tmp[1, 1] = -4 * dq - 1 * ds + 4 * dt   # dzx
     tmp[2, 2] = -4 * dq - 1 * ds + 4 * dt   # dzy
@@ -62,8 +61,8 @@ def ed():
     ncfg_i, ncfg_n = len(basis_i), len(basis_n)
 
     # Build many-body Hamiltonian in Fock basis
-    hmat_i = np.zeros((ncfg_i, ncfg_i), dtype=np.complex)
-    hmat_n = np.zeros((ncfg_n, ncfg_n), dtype=np.complex)
+    hmat_i = np.zeros((ncfg_i, ncfg_i), dtype=complex)
+    hmat_n = np.zeros((ncfg_n, ncfg_n), dtype=complex)
     hmat_i[:, :] += edrixs.two_fermion(emat_i, basis_i, basis_i)
     hmat_i[:, :] += edrixs.four_fermion(umat_i, basis_i)
     hmat_n[:, :] += edrixs.two_fermion(emat_n, basis_n, basis_n)
@@ -74,9 +73,9 @@ def ed():
     eval_n, evec_n = np.linalg.eigh(hmat_n)
 
     # Build dipolar transition operators
-    dipole = np.zeros((3, ntot, ntot), dtype=np.complex)
-    T_abs = np.zeros((3, ncfg_n, ncfg_i), dtype=np.complex)
-    T_emi = np.zeros((3, ncfg_i, ncfg_n), dtype=np.complex)
+    dipole = np.zeros((3, ntot, ntot), dtype=complex)
+    T_abs = np.zeros((3, ncfg_n, ncfg_i), dtype=complex)
+    T_emi = np.zeros((3, ncfg_i, ncfg_n), dtype=complex)
     tmp = edrixs.get_trans_oper('dp')
     for i in range(3):
         dipole[i, 0:ndorb, ndorb:ntot] = tmp[i]
@@ -96,7 +95,7 @@ def xas(eval_i, eval_n, T_abs):
     Gam_c = 0.2  # core-hole life-time broadening
     pol = np.array([1.0, 1.0, 1.0]) / np.sqrt(3.0)  # isotropic
     omega = np.linspace(-10, 20, 1000)
-    xas = np.zeros(len(omega), dtype=np.float)
+    xas = np.zeros(len(omega), dtype=float)
     # Calculate XAS spectrum
     for i, om in enumerate(omega):
         for j in gs:
@@ -135,14 +134,14 @@ def rixs(eval_i, eval_n, T_abs, T_emi):
     pol = [(0, 0), (0, np.pi / 2.0)]  # pi-pi and pi-sigma polarization
     omega = np.linspace(-5.9, -0.9, 100)
     eloss = np.linspace(-0.5, 5.0, 1000)
-    rixs = np.zeros((len(pol), len(eloss), len(omega)), dtype=np.float)
+    rixs = np.zeros((len(pol), len(eloss), len(omega)), dtype=float)
 
     # Calculate RIXS
     for i, om in enumerate(omega):
         F_fi = edrixs.scattering_mat(eval_i, eval_n, T_abs[:, :, gs], T_emi, om, Gam_c)
         for j, (alpha, beta) in enumerate(pol):
             ei, ef = edrixs.dipole_polvec_rixs(thin, thout, phi, alpha, beta)
-            F_mag = np.zeros((len(eval_i), len(gs)), dtype=np.complex)
+            F_mag = np.zeros((len(eval_i), len(gs)), dtype=complex)
             for m in range(3):
                 for n in range(3):
                     F_mag[:, :] += ef[m] * F_fi[m, n] * ei[n]

--- a/examples/cpc/two_site_cluster/get_inputs.py
+++ b/examples/cpc/two_site_cluster/get_inputs.py
@@ -114,7 +114,7 @@ def get_hopping_coulomb(locaxis):
          [t1, t2, t1, 0, delta, delta],
          [t2, t1, t1, delta, 0, delta],
          [t1, t1, t2, delta, delta, 0]
-         ], dtype=np.complex)
+         ], dtype=complex)
 
     # transform spin to local axis
     dmat = np.zeros((2, 2, 2), dtype=np.complex128)
@@ -177,7 +177,7 @@ def get_fock_basis():
 
 def get_transop(loc, pos):
     dop = edrixs.get_trans_oper('t2gp')
-    dop_g = np.zeros((2, 3, 6, 6), dtype=np.complex)
+    dop_g = np.zeros((2, 3, 6, 6), dtype=complex)
     for i in range(2):
         dop_g[i, 0] = loc[i, 0, 0] * dop[0] + loc[i, 0, 1] * dop[1] + loc[i, 0, 2] * dop[2]
         dop_g[i, 1] = loc[i, 1, 0] * dop[0] + loc[i, 1, 1] * dop[1] + loc[i, 1, 2] * dop[2]
@@ -190,15 +190,15 @@ def get_transop(loc, pos):
     # polarization pi-pi and pi-sigma
     for key, alpha, beta in [('pp', 0, 0), ('ps', 0, np.pi)]:
         ei, ef = edrixs.dipole_polvec_rixs(thin, thout, phi, alpha, beta)
-        T_i = np.zeros((2, 6, 6), dtype=np.complex)
-        T_o = np.zeros((2, 6, 6), dtype=np.complex)
+        T_i = np.zeros((2, 6, 6), dtype=complex)
+        T_o = np.zeros((2, 6, 6), dtype=complex)
         for i in range(2):
             T_i[i] = (dop_g[i, 0] * ei[0] + dop_g[i, 1] * ei[1] +
                       dop_g[i, 2] * ei[2]) * np.exp(1j * np.dot(pos[i], kin))
             T_o[i] = np.exp(-1j * np.dot(pos[i], kout)) * np.conj(
                 np.transpose(dop_g[i, 0] * ef[0] + dop_g[i, 1] * ef[1] + dop_g[i, 2] * ef[2]))
-        transop_rixs_i = np.zeros((24, 24), dtype=np.complex)
-        transop_rixs_f = np.zeros((24, 24), dtype=np.complex)
+        transop_rixs_i = np.zeros((24, 24), dtype=complex)
+        transop_rixs_f = np.zeros((24, 24), dtype=complex)
         for i in range(2):
             off1, off2 = i * 6, 12 + i * 6
             transop_rixs_i[off1:off1 + 6, off2:off2 + 6] = T_i[i]
@@ -208,7 +208,7 @@ def get_transop(loc, pos):
 
     # For XAS
     ei = np.array([1, 1, 1]) / np.sqrt(3.0)
-    T_i = np.zeros((2, 6, 6), dtype=np.complex)
+    T_i = np.zeros((2, 6, 6), dtype=complex)
     for i in range(2):
         T_i[i] = dop_g[i, 0] * ei[0] + dop_g[i, 1] * ei[1] + dop_g[i, 2] * ei[2]
     transop_xas = np.zeros((24, 24), dtype=np.complex128)

--- a/examples/more/ED/6orb/run_ed.py
+++ b/examples/more/ED/6orb/run_ed.py
@@ -83,7 +83,7 @@ Jz = Jxyz[2]
 # First, write their matrice in the real harmonics basis
 # |dxz,up>, |dxz,dn>, |dyz,up>, |dyz,dn>, |dxy,up>, |dxy,dn>
 # In this basis, they take simple form, only the diagonal terms have element 1
-nd_oper = np.zeros((norb, norb, norb), dtype=np.complex)
+nd_oper = np.zeros((norb, norb, norb), dtype=complex)
 nd_oper[0, 0, 0] = 1
 nd_oper[1, 1, 1] = 1
 nd_oper[2, 2, 2] = 1

--- a/examples/more/RIXS/Ba2YOsO6/Anderson_model/run_rixs_fsolver.py
+++ b/examples/more/RIXS/Ba2YOsO6/Anderson_model/run_rixs_fsolver.py
@@ -34,8 +34,8 @@ if __name__ == "__main__":
     norb = 6   # number of orbitals for each site
 
     # bath energy level & hybridization strength
-    bath_level = np.zeros((nbath, norb), dtype=np.complex)
-    hyb = np.zeros((nbath, norb), dtype=np.complex)
+    bath_level = np.zeros((nbath, norb), dtype=complex)
+    hyb = np.zeros((nbath, norb), dtype=complex)
     e1 = [-3.528372861516216, -1.207615555008166, 6.183392524170465]
     e2 = [-3.538890277572901, -1.308137924011529, 5.578400781316763]
     v1 = [2.131943931119928, 0.481470627582356, 1.618130554107574]
@@ -46,7 +46,7 @@ if __name__ == "__main__":
     hyb[:, 2] = hyb[:, 3] = hyb[:, 4] = hyb[:, 5] = v2  # j=3/2
 
     # impurity matrix
-    imp_mat = np.zeros((6, 6), dtype=np.complex)
+    imp_mat = np.zeros((6, 6), dtype=complex)
     imp_mat[0, 0] = imp_mat[1, 1] = -14.7627972353
     imp_mat[2, 2] = imp_mat[3, 3] = imp_mat[4, 4] = imp_mat[5, 5] = -15.4689430453
 

--- a/examples/more/RIXS/Pyrochlore_227/Ir_d5/single_atom/run_rixs_pysolver.py
+++ b/examples/more/RIXS/Pyrochlore_227/Ir_d5/single_atom/run_rixs_pysolver.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
                     ('linear', np.pi / 2.0, 'linear', 0.0),
                     ('linear', np.pi / 2.0, 'linear', np.pi / 2.0)]
 
-    rixs = np.zeros((len(ominc), len(eloss), len(poltype_rixs), natom), dtype=np.float)
+    rixs = np.zeros((len(ominc), len(eloss), len(poltype_rixs), natom), dtype=float)
     # Loop over all the atoms
     for iatom in range(natom):
         print()

--- a/examples/more/RIXS/Pyrochlore_227/Os_d3/single_atom/run_rixs_pysolver.py
+++ b/examples/more/RIXS/Pyrochlore_227/Os_d3/single_atom/run_rixs_pysolver.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
                     ('linear', np.pi / 2.0, 'linear', 0.0),
                     ('linear', np.pi / 2.0, 'linear', np.pi / 2.0)]
 
-    rixs = np.zeros((len(ominc), len(eloss), len(poltype_rixs), natom), dtype=np.float)
+    rixs = np.zeros((len(ominc), len(eloss), len(poltype_rixs), natom), dtype=float)
     # Loop over all the atoms
     for iatom in range(natom):
         print()

--- a/examples/sphinx/example_1_crystal_field.py
+++ b/examples/sphinx/example_1_crystal_field.py
@@ -143,7 +143,7 @@ print("{} distinct energies".format(len(unique_e)))
 # out the
 # `numpy indexing notes <https://numpy.org/doc/stable/reference/arrays.indexing.html>`_
 # if needed.
-nd_real_harmoic_basis = np.zeros((norb, norb, norb), dtype=np.complex)
+nd_real_harmoic_basis = np.zeros((norb, norb, norb), dtype=complex)
 indx = np.arange(norb)
 nd_real_harmoic_basis[indx, indx, indx] = 1
 

--- a/examples/sphinx/example_2_single_atom_RIXS.py
+++ b/examples/sphinx/example_2_single_atom_RIXS.py
@@ -2,13 +2,13 @@
 """
 RIXS calculations for an atomic model
 =====================================
-Here we show how to compute RIXS for a single site atomic model with crystal 
-field and electron-electron interactions. We take the case of 
+Here we show how to compute RIXS for a single site atomic model with crystal
+field and electron-electron interactions. We take the case of
 Sr\ :sub:`2`\ YIrO\ :sub:`6`
-from Ref. [1]_ as the material in question. The aim of this example is to 
+from Ref. [1]_ as the material in question. The aim of this example is to
 illustrate the proceedure and to provide what we hope is useful advice. What is
 written is not meant to be a replacement for reading the docstrings of the
-functions, which can always be accessed on the 
+functions, which can always be accessed on the
 `edrixs website <https://nsls-ii.github.io/edrixs/reference/index.html>`_ or
 by executing functions with ?? in IPython.
 """
@@ -20,8 +20,8 @@ import matplotlib.pyplot as plt
 # Specify active core and valence orbitals
 # ------------------------------------------------------------------------------
 # Sr\ :sub:`2`\ YIrO\ :sub:`6`\  has a :math:`5d^4` electronic configuration and
-# we want to calculate the :math:`L_3` edge spectrum i.e. resonating with a 
-# :math:`2p_{3/2}` core hole. We will start by including only the 
+# we want to calculate the :math:`L_3` edge spectrum i.e. resonating with a
+# :math:`2p_{3/2}` core hole. We will start by including only the
 # :math:`t_{2g}` valance orbitals.
 shell_name = ('t2g', 'p32')
 v_noccu = 4
@@ -29,7 +29,7 @@ v_noccu = 4
 ################################################################################
 # Slater parameters
 # ------------------------------------------------------------------------------
-# Here we want to use Hund's interaction 
+# Here we want to use Hund's interaction
 # :math:`J_H` and spin orbit coupling :math:`\lambda` as adjustable parameters
 # to match experiment. We will take
 # the core hole interaction parameter from the Hartree Fock numbers EDRIXS has
@@ -40,7 +40,7 @@ JH = 0.25
 lam = 0.42
 F0_d, F2_d, F4_d = edrixs.UdJH_to_F0F2F4(Ud, JH)
 info = edrixs.utils.get_atom_data('Ir', '5d', v_noccu, edge='L3')
-G1_dp  = info['slater_n'][5][1]
+G1_dp = info['slater_n'][5][1]
 G3_dp = info['slater_n'][6][1]
 F0_dp = edrixs.get_F0('dp', G1_dp, G3_dp)
 F2_dp = info['slater_n'][4][1]
@@ -62,8 +62,8 @@ v_soc = (lam, lam)
 # operators via matrix diagonalization. Note that the calculation does not know
 # the core hole energy, so we need to adjust the energy that the resonance will
 # appear at by hand. We know empirically that the resonance is at 11215 eV
-# and that putting four electrons into the valance band costs about 
-# :math:`4 F^0_d\approx6` eV. In this case 
+# and that putting four electrons into the valance band costs about
+# :math:`4 F^0_d\approx6` eV. In this case
 # we are assuming a perfectly cubic crystal field, which we have already
 # implemented when we specified the use of the :math:`t_{2g}` subshell only
 # so we do not need to pass an additional :code:`v_cfmat` matrix.
@@ -78,14 +78,14 @@ eval_i, eval_n, trans_op = out
 # ------------------------------------------------------------------------------
 # To calculate XAS we need to correctly specify the orientation of the x-rays
 # with respect to the sample. By default, the :math:`x, y, z` coordinates
-# of the sample's crystal field, will be aligned with our lab frame, passing 
-# :code:`loc_axis` to :code:`ed_1v1c_py` can be used to specify a different 
+# of the sample's crystal field, will be aligned with our lab frame, passing
+# :code:`loc_axis` to :code:`ed_1v1c_py` can be used to specify a different
 # convention. The experimental geometry is specified following the angles
 # shown in Figure 1 of Y. Wang et al.,
 # `Computer Physics Communications 243, 151-165 (2019)
-# <https://doi.org/10.1016/j.cpc.2019.04.018>`_. The default 
+# <https://doi.org/10.1016/j.cpc.2019.04.018>`_. The default
 # setting has x-rays along :math:`z` for :math:`\theta=\pi` rad
-# and the x-ray beam along :math:`-x` for 
+# and the x-ray beam along :math:`-x` for
 # :math:`\theta=\phi=0`. Parameter :code:`scatter_axis` can be passed to
 # :code:`xas_1v1c_py` to specify a different geometry if desired.
 #
@@ -102,9 +102,9 @@ eval_i, eval_n, trans_op = out
 # which is the Lorentzian half width at half maximum.
 
 ominc = np.linspace(11200, 11230, 50)
-temperature = 300 # in K
+temperature = 300  # in K
 prob = edrixs.boltz_dist(eval_i, temperature)
-gs_list = [n for n, prob in enumerate(prob) if prob>1e-6]
+gs_list = [n for n, prob in enumerate(prob) if prob > 1e-6]
 
 gs_list = [n for n in range(6)]
 
@@ -122,15 +122,15 @@ xas = edrixs.xas_1v1c_py(
 # Compute RIXS
 # ------------------------------------------------------------------------------
 # Calculating RIXS is overall similar to XAS, but with a few additional
-# considerations. The spectral width in the energy loss axis of RIXS it 
+# considerations. The spectral width in the energy loss axis of RIXS it
 # not set by the core hole lifetime, but by either the final state lifetime
-# or the experimental resolution and is parameterized by :code:`gamma_f` 
+# or the experimental resolution and is parameterized by :code:`gamma_f`
 # -- the Lorentzian half width at half maximum.
-# 
+#
 # The angle and polarization of the emitted beam must also be specified.
 # If, as is common in experiments, the emitted polarization is not resolved
 # one needs to add both emitted polarization channels, which is what we will
-# do later on in this example. 
+# do later on in this example.
 
 eloss = np.linspace(-.5, 6, 400)
 pol_type_rixs = [('linear', 0, 'linear', 0), ('linear', 0, 'linear', np.pi/2)]
@@ -155,35 +155,35 @@ rixs = edrixs.rixs_1v1c_py(
 # ------------------------------------------------------------------------------
 # Let's plot everything. We will use a function so we can reuse the code later.
 # Note that the rixs array :code:`rixs` has shape
-# :code:`(len(ominc_xas), len(ominc_xas), len(pol_type))`. We will use some numpy 
+# :code:`(len(ominc_xas), len(ominc_xas), len(pol_type))`. We will use some numpy
 # tricks to sum over the two different emitted polarizations.
 
 fig, axs = plt.subplots(2, 2, figsize=(10, 10))
+
 
 def plot_it(axs, ominc, xas, eloss, rixscut, rixsmap=None, label=None):
     axs[0].plot(ominc, xas[:, 0], label=label)
     axs[0].set_xlabel('Energy (eV)')
     axs[0].set_ylabel('Intensity')
     axs[0].set_title('XAS')
-    
-
 
     axs[1].plot(eloss, rixscut, label=f"{label}")
     axs[1].set_xlabel('Energy loss (eV)')
     axs[1].set_ylabel('Intensity')
     axs[1].set_title(f'RIXS at resonance')
-    
+
     if rixsmap is not None:
-        art = axs[2].pcolor(ominc, eloss, rixsmap.T)
+        art = axs[2].pcolormesh(ominc, eloss, rixsmap.T, shading='auto')
         plt.colorbar(art, ax=axs[2], label='Intensity')
         axs[2].set_xlabel('Incident energy (eV)')
         axs[2].set_ylabel('Energy loss')
         axs[2].set_title('RIXS map')
 
+
 rixs_pol_sum = rixs.sum(-1)
-cut_index  = np.argmax(rixs_pol_sum[:, eloss<2].sum(1))
+cut_index = np.argmax(rixs_pol_sum[:, eloss < 2].sum(1))
 rixscut = rixs_pol_sum[cut_index]
-    
+
 plot_it(axs.ravel(), ominc, xas, eloss, rixscut, rixsmap=rixs_pol_sum)
 axs[0, 1].set_xlim(right=3)
 axs[1, 0].set_ylim(top=3)
@@ -203,7 +203,7 @@ plt.show()
 ten_dq = 3.5
 v_cfmat = edrixs.cf_cubic_d(ten_dq)
 off = 11215 - 6 + ten_dq*2/5
-out = edrixs.ed_1v1c_py(('d', 'p32'), shell_level=(0, -off), v_soc=v_soc, 
+out = edrixs.ed_1v1c_py(('d', 'p32'), shell_level=(0, -off), v_soc=v_soc,
                         v_cfmat=v_cfmat,
                         c_soc=info['c_soc'], v_noccu=v_noccu, slater=slater)
 eval_i, eval_n, trans_op = out
@@ -241,6 +241,6 @@ plt.show()
 #
 # .. [1] Bo Yuan et al.,
 #        `Phys. Rev. B 95, 235114 (2017) <https://doi.org/10.1103/PhysRevB.95.235114>`_.
-# 
+#
 # .. [2] Georgios L. Stamokostas and Gregory A. Fiete
 #        `Phys. Rev. B 97, 085150 (2018) <https://doi.org/10.1103/PhysRevB.97.085150>`_.

--- a/examples/sphinx/example_3_AIM_XAS.py
+++ b/examples/sphinx/example_3_AIM_XAS.py
@@ -151,7 +151,7 @@ trans_c2n = edrixs.tmat_c2r('d',True)
 # are used here. See :ref:`sphx_glr_auto_examples_example_1_crystal_field.py`
 # for more details if needed.
 ten_dq = 0.56
-CF = np.zeros((norb_d, norb_d), dtype=np.complex)
+CF = np.zeros((norb_d, norb_d), dtype=complex)
 diagonal_indices = np.arange(norb_d)
 
 orbital_energies = np.array([e for orbital_energy in
@@ -186,12 +186,12 @@ imp_mat_n = CF + soc + E_dc_mat
 # only one bath, with 10 spin-orbitals. We initialize the matrix to
 # :code:`norb_d` and then split the energies according to :code:`ten_dq_bath`.
 ten_dq_bath = 1.44
-bath_level = np.full((nbath, norb_d), E_L, dtype=np.complex)
+bath_level = np.full((nbath, norb_d), E_L, dtype=complex)
 bath_level[0, :2] += ten_dq_bath*.6  # 3z2-r2
 bath_level[0, 2:6] -= ten_dq_bath*.4  # zx/yz
 bath_level[0, 6:8] += ten_dq_bath*.6  # x2-y2
 bath_level[0, 8:] -= ten_dq_bath*.4  # xy
-bath_level_n = np.full((nbath, norb_d), E_Lc, dtype=np.complex)
+bath_level_n = np.full((nbath, norb_d), E_Lc, dtype=complex)
 bath_level_n[0, :2] += ten_dq_bath*.6  # 3z2-r2
 bath_level_n[0, 2:6] -= ten_dq_bath*.4  # zx/yz
 bath_level_n[0, 6:8] += ten_dq_bath*.6  # x2-y2
@@ -206,7 +206,7 @@ bath_level_n[0, 8:] -= ten_dq_bath*.4  # xy
 Veg = 2.06
 Vt2g = 1.21
 
-hyb = np.zeros((nbath, norb_d), dtype=np.complex)
+hyb = np.zeros((nbath, norb_d), dtype=complex)
 hyb[0, :2] = Veg  # 3z2-r2
 hyb[0, 2:6] = Vt2g  # zx/yz
 hyb[0, 6:8] = Veg  # x2-y2

--- a/examples/sphinx/example_4_GS_analysis.py
+++ b/examples/sphinx/example_4_GS_analysis.py
@@ -62,7 +62,7 @@ ntot = 20
 # first :math:`10\times10\times10\times 10` indices of the matrix. edrixs
 # creates this matrix in the complex harmmonic basis by default.
 umat_delectrons = edrixs.get_umat_slater('d', F0_dd, F2_dd, F4_dd)
-umat = np.zeros((ntot, ntot, ntot, ntot), dtype=np.complex)
+umat = np.zeros((ntot, ntot, ntot, ntot), dtype=complex)
 umat[:norb_d, :norb_d, :norb_d, :norb_d] += umat_delectrons
 
 
@@ -94,7 +94,7 @@ emat_rhb[indx2, indx1] += np.conj(hyb[0])
 # We now need to transform into the complex harmonic basis. We assign
 # the two diagonal blocks of a :math:`20\times20` matrix to the
 # conjugate transpose of the transition matrix.
-tmat = np.eye(ntot, dtype=np.complex)
+tmat = np.eye(ntot, dtype=complex)
 for i in range(2):
     off = i * norb_d
     tmat[off:off+norb_d, off:off+norb_d] = np.conj(np.transpose(trans_c2n))


### PR DESCRIPTION
This includes many small changes to address issues #132 and #120 and associated warnings that occur when running the code and generating the docs. Please refer to these issues.

Since ```np.complex``` is equivalent to ```complex``` and equivalent for ```np.float``` and ```np.int``` almost all the changes should include no change in functionality. 

This line from the docs is inequivalent, but not in any significant way. 
```
art = axs[2].pcolormesh(ominc, eloss, rixsmap.T, shading='auto')
```