### PR TITLE
Mac os

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ If you are using the EDRIXS code to do some studies and would like to publish yo
 ``EDRIXS: An open source toolkit for simulating spectra of resonant inelastic x-ray scattering, Y.L. Wang, G. Fabbris, M.P.M. Dean and G. Kotliar``, `Computer Physics Communications,243, 151 (2019) <https://doi.org/10.1016/j.cpc.2019.04.018>`_, `arXiv:1812.05735 <https://arxiv.org/abs/1812.05735/>`_.
 
 
-Install via Anaconda (only Linux now)
+Install via Anaconda for Linux and macOS
 -------------------------------------
 
   .. code-block:: bash

--- a/docs/source/user/installation.rst
+++ b/docs/source/user/installation.rst
@@ -1,26 +1,14 @@
 ************
 Installation
 ************
-For those who just want to get started, using the :ref:`docker instructions <edrixsanddocker>` is relatively straightforward and is compatible with essentially all platforms. For linux users :ref:`installing with anaconda <AnacondaInstall>` should also be easy. You can also compile the code from the source for Linux and OSX.
+For linux and macOS users we suggest :ref:`installing with anaconda <AnacondaInstall>`. For Windows machines, we suggest using the :ref:`docker instructions <edrixsanddocker>`, which are relatively straightforward.  If desired, you can also compile the code from the source for Linux and macOS.
 
-Requirements
-============
-Several tools and libraries are required to build and install edrixs,
-
-   * Fortran compiler: gfortran and ifort are supported
-   * MPI environment: openmpi and mpich are tested
-   * MPI Fortran and C compilers: mpif90, mpicc
-   * BLAS and LAPACK libraries: `OpenBLAS <https://github.com/xianyi/OpenBLAS/>`_ with gfortran and MKL with ifort
-   * ARPACK library: `arpack-ng <https://github.com/opencollab/arpack-ng/>`_  with mpi enabled
-   * Only Python3 is supported
-   * numpy, scipy, sympy, matplotlib, sphinx, numpydoc
-   * mpi4py with same MPI compilers as building edrixs
 
 .. _AnacondaInstall:
 
-Install and use edrixs via Anaconda (only Linux now)
+Install and use edrixs via Anaconda
 ====================================================
-A conda package has been built for Linux systems. To use edrixs via Anaconda, you need first to install `Anaconda <https://www.anaconda.com/distribution/>`_ in your system.
+A conda package has been built for Linux and macOS systems. To use edrixs via Anaconda, you need first to install `Anaconda <https://www.anaconda.com/distribution/>`_ in your system.
 Then, create and activate a conda env, for example, called ``edrixs_env``::
 
     conda create --name edrixs_env python=3.7
@@ -41,11 +29,24 @@ edrixs will also run on `Google Colaboratory <https://research.google.com/colabo
 
 from within a notebook cell.
 
+Requirements
+============
+Several tools and libraries are required to build and install edrixs,
+
+   * Fortran compiler: gfortran and ifort are supported
+   * MPI environment: openmpi and mpich are tested
+   * MPI Fortran and C compilers: mpif90, mpicc
+   * BLAS and LAPACK libraries: `OpenBLAS <https://github.com/xianyi/OpenBLAS/>`_ with gfortran and MKL with ifort
+   * ARPACK library: `arpack-ng <https://github.com/opencollab/arpack-ng/>`_  with mpi enabled
+   * Only Python3 is supported
+   * numpy, scipy, sympy, matplotlib, sphinx, numpydoc
+   * mpi4py with same MPI compilers as building edrixs
+
 Build from source
 =================
 We will show how to build edrixs from source on Ubuntu Linux 18.04 and macOS Mojave (OSX 10.14) as examples.
 We will use gcc, gfortran, openmpi and OpenBLAS in these examples.
-Building edrixs on other versions of Linux or OSX, or with Intel's ifort+MKL will be similar.
+Building edrixs on other versions of Linux or macOS, or with Intel's ifort+MKL will be similar.
 
 Ubuntu Linux 18.04
 ------------------
@@ -359,6 +360,6 @@ if no errors, the installation is successful.
 
 All done, enjoy!
 
-.. [#] To change your default python you need to add a line to your ``~/.bashrc`` on linux or to your ``~/.bash_profile`` on OSX. This should be ``alias python='/usr/local/bin/python3'`` where the path is determined by calling ``which python3`` from your terminal.
+.. [#] To change your default python you need to add a line to your ``~/.bashrc`` on linux or to your ``~/.bash_profile`` on macOS. This should be ``alias python='/usr/local/bin/python3'`` where the path is determined by calling ``which python3`` from your terminal.
 
-.. [#] To change your default pip you need to add a line to your ``~/.bashrc`` on linux or to your ``~/.bash_profile`` on OSX. This should be ``alias pip='/usr/bin/pip3'`` where the path is determined by calling ``which pip3`` from your terminal.
+.. [#] To change your default pip you need to add a line to your ``~/.bashrc`` on linux or to your ``~/.bash_profile`` on macOS. This should be ``alias pip='/usr/bin/pip3'`` where the path is determined by calling ``which pip3`` from your terminal.

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -13,7 +13,7 @@ sudo apt-get install -y \
 # These packages are installed in the base environment but may be older
 # versions. Explicitly upgrade them because they often create
 # installation problems if out of date.
-python -m pip install --upgrade pip setuptools numpy
+python -m pip install --upgrade pip setuptools==65.5.* numpy
 
 # Compile Fortran code
 make -C src


### PR DESCRIPTION
This updates the docs to cover the new conda install for macOS and it pins setuptools, which seems to now be required as anticipated in #157 .