### PR TITLE
remove codecov

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 # These are required for developing the package (running the tests, building
 # the documentation) but not necessarily required for _using_ it.
-codecov
 coverage
 flake8
 pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 # These are required for developing the package (running the tests, building
 # the documentation) but not necessarily required for _using_ it.
+pytest-codecov
 coverage
 flake8
 pytest


### PR DESCRIPTION
Our build seems to throw errors

```ERROR: No matching distribution found for codecov```


@mrakitin could you confirm that this should be removed?