### PR TITLE
Update solvers.py

### DIFF
--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -529,7 +529,7 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
                
 
         for j, (it, alpha, jt, beta) in enumerate(pol_type):
-            if ((it=='isotropic')||(jt=='isotropic')):
+            if ((it=='isotropic') or (jt=='isotropic')):
                 ei=np.ones(3)/np.sqrt(3)                        # Powder spectrum
                 ef=np.ones(3)/np.sqrt(3)
             else:        

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -558,7 +558,7 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
             if skip_gs:
                 exc_ind = len(gs_list)
             for m, igs in enumerate(gs_list):
-                for n in range(excInd, len(eval_i)):
+                for n in range(exc_ind, len(eval_i)):
                     rixs[i, :, j] += (
                         prob[m] * np.abs(F_mag[n, igs])**2 * gamma_final / np.pi /
                         ((eloss - (eval_i[n] - eval_i[igs]))**2 + gamma_final**2)

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -530,7 +530,7 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
                               trans_emi, om, gamma_core[i])
 
         for j, (it, alpha, jt, beta) in enumerate(pol_type):
-            if ((it == 'isotropic') or (jt == 'isotropic')):
+            if (it == 'isotropic') or (jt == 'isotropic'):
                 ei = np.ones(3)/np.sqrt(3)                        # Powder spectrum
                 ef = np.ones(3)/np.sqrt(3)
             else:
@@ -555,7 +555,7 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
                     F_mag[:, :] += np.conj(polvec_f[m]) * F_fi[m, n] * polvec_i[n]
 
             excInd = 0
-            if (skipGS):
+            if skipGS:
                 excInd = len(gs_list)
             for m, igs in enumerate(gs_list):
                 for n in range(excInd, len(eval_i)):

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -554,9 +554,10 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
                     F_mag[:, :] += np.conj(polvec_f[m]) * F_fi[m, n] * polvec_i[n]
            
            excInd = 0
-           if (skipGS) excInd = len(gs_list) 
+           if (skipGS):
+               excInd = len(gs_list) 
            for m, igs in enumerate(gs_list):
-                for n in range(excInd:len(eval_i)):
+                for n in range(excInd,len(eval_i)):
                     rixs[i, :, j] += (
                         prob[m] * np.abs(F_mag[n, igs])**2 * gamma_final / np.pi /
                         ((eloss - (eval_i[n] - eval_i[igs]))**2 + gamma_final**2)

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -459,7 +459,7 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
         the angle (in radians) between the linear polarization vector and the scattering plane.
 
         If str1 (or str2) is 'isotropic' then the polarization vector projects equally
-        variables are ignored.
+        along each axis and the other variables are ignored.
 
         It will set pol_type=[('linear', 0, 'linear', 0)] if not provided.
     gs_list: 1d list of ints

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -480,7 +480,8 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
 
         It will be an identity matrix if not provided.
     skipGS: bool
-        If True, transitions to the ground state(s) (forming the direct peak) are omitted from the calculation. 
+        If True, transitions to the ground state(s) (forming the direct peak) are omitted from
+        the calculation.
 
     Returns
     -------
@@ -532,9 +533,9 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
             if ((it == 'isotropic') or (jt == 'isotropic')):
                 ei = np.ones(3)/np.sqrt(3)                        # Powder spectrum
                 ef = np.ones(3)/np.sqrt(3)
-            else:        
+            else:
                 ei, ef = dipole_polvec_rixs(thin, thout, phi, alpha, beta,
-                                            scatter_axis, (it, jt))    
+                                            scatter_axis, (it, jt))
             # dipolar transition
             if npol == 3:
                 polvec_i[:] = ei
@@ -552,10 +553,10 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
             for m in range(npol):
                 for n in range(npol):
                     F_mag[:, :] += np.conj(polvec_f[m]) * F_fi[m, n] * polvec_i[n]
-           
+
             excInd = 0
             if (skipGS):
-                excInd = len(gs_list) 
+                excInd = len(gs_list)
             for m, igs in enumerate(gs_list):
                 for n in range(excInd, len(eval_i)):
                     rixs[i, :, j] += (

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -480,7 +480,7 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
 
         It will be an identity matrix if not provided.
     skipGS: bool
-        If True, transitions to the ground state(s) (forming the direct peak) are omitted from
+        If True, transitions to the ground state(s) (forming the elastic peak) are omitted from
         the calculation.
 
     Returns

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -479,7 +479,7 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
         - local :math:`z`-axis: scatter_axis[:,2]
 
         It will be an identity matrix if not provided.
-    skipGS: bool
+    skip_gs: bool
         If True, transitions to the ground state(s) (forming the elastic peak) are omitted from
         the calculation.
 

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -556,7 +556,7 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
 
             fs_list = np.arange(len(eval_i))
             if skip_gs:
-                fs_list = np.delete(fs_list,gs_list)
+                fs_list = np.delete(fs_list, gs_list)
             for m, igs in enumerate(gs_list):
                 for n in fs_list:
                     rixs[i, :, j] += (

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -530,12 +530,12 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
                               trans_emi, om, gamma_core[i])
 
         for j, (it, alpha, jt, beta) in enumerate(pol_type):
-            if (it == 'isotropic') or (jt == 'isotropic'):
+            ei, ef = dipole_polvec_rixs(thin, thout, phi, alpha, beta,
+                                                          scatter_axis, (it, jt))
+            if it.lower() == 'isotropic':
                 ei = np.ones(3)/np.sqrt(3)                        # Powder spectrum
+             if jt.lower() == 'isotropic':   
                 ef = np.ones(3)/np.sqrt(3)
-            else:
-                ei, ef = dipole_polvec_rixs(thin, thout, phi, alpha, beta,
-                                            scatter_axis, (it, jt))
             # dipolar transition
             if npol == 3:
                 polvec_i[:] = ei

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -555,7 +555,7 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
                     F_mag[:, :] += np.conj(polvec_f[m]) * F_fi[m, n] * polvec_i[n]
 
             excInd = 0
-            if skipGS:
+            if skip_gs:
                 excInd = len(gs_list)
             for m, igs in enumerate(gs_list):
                 for n in range(excInd, len(eval_i)):

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -554,11 +554,11 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
                 for n in range(npol):
                     F_mag[:, :] += np.conj(polvec_f[m]) * F_fi[m, n] * polvec_i[n]
 
-            exc_ind = 0
+            fs_list = np.arange(len(eval_i))
             if skip_gs:
-                exc_ind = len(gs_list)
+                fs_list = np.delete(fs_list,gs_list)
             for m, igs in enumerate(gs_list):
-                for n in range(exc_ind, len(eval_i)):
+                for n in fs_list:
                     rixs[i, :, j] += (
                         prob[m] * np.abs(F_mag[n, igs])**2 * gamma_final / np.pi /
                         ((eloss - (eval_i[n] - eval_i[igs]))**2 + gamma_final**2)

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -458,7 +458,8 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
         where, str1 (str2) can be 'linear', 'left', 'right', 'isotropic' and alpha (beta) is
         the angle (in radians) between the linear polarization vector and the scattering plane.
 
-        If str1 or str2 is 'isotropic' then the scattering is considered isotropic and the other variables are ignored.
+        If str1 or str2 is 'isotropic' then the scattering is considered isotropic and the other
+        variables are ignored.
 
         It will set pol_type=[('linear', 0, 'linear', 0)] if not provided.
     gs_list: 1d list of ints
@@ -526,16 +527,15 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
     for i, om in enumerate(ominc):
         F_fi = scattering_mat(eval_i, eval_n, trans_op[:, :, 0:max(gs_list)+1],
                               trans_emi, om, gamma_core[i])
-               
 
         for j, (it, alpha, jt, beta) in enumerate(pol_type):
-            if ((it=='isotropic') or (jt=='isotropic')):
-                ei=np.ones(3)/np.sqrt(3)                        # Powder spectrum
-                ef=np.ones(3)/np.sqrt(3)
+            if ((it == 'isotropic') or (jt == 'isotropic')):
+                ei = np.ones(3)/np.sqrt(3)                        # Powder spectrum
+                ef = np.ones(3)/np.sqrt(3)
             else:        
                 ei, ef = dipole_polvec_rixs(thin, thout, phi, alpha, beta,
-                                        scatter_axis, (it, jt))    
-           # dipolar transition
+                                            scatter_axis, (it, jt))    
+            # dipolar transition
             if npol == 3:
                 polvec_i[:] = ei
                 polvec_f[:] = ef
@@ -557,7 +557,7 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
             if (skipGS):
                 excInd = len(gs_list) 
             for m, igs in enumerate(gs_list):
-                for n in range(excInd,len(eval_i)):
+                for n in range(excInd, len(eval_i)):
                     rixs[i, :, j] += (
                         prob[m] * np.abs(F_mag[n, igs])**2 * gamma_final / np.pi /
                         ((eloss - (eval_i[n] - eval_i[igs]))**2 + gamma_final**2)

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -458,7 +458,7 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
         where, str1 (str2) can be 'linear', 'left', 'right', 'isotropic' and alpha (beta) is
         the angle (in radians) between the linear polarization vector and the scattering plane.
 
-        If str1 or str2 is 'isotropic' then the scattering is considered isotropic and the other
+        If str1 (or str2) is 'isotropic' then the polarization vector projects equally
         variables are ignored.
 
         It will set pol_type=[('linear', 0, 'linear', 0)] if not provided.

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -531,7 +531,7 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
 
         for j, (it, alpha, jt, beta) in enumerate(pol_type):
             ei, ef = dipole_polvec_rixs(thin, thout, phi, alpha, beta,
-                                                          scatter_axis, (it, jt))
+                                            scatter_axis, (it, jt))
             if it.lower() == 'isotropic':
                 ei = np.ones(3)/np.sqrt(3)                        # Powder spectrum
             if jt.lower() == 'isotropic':   
@@ -554,7 +554,7 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
                 for n in range(npol):
                     F_mag[:, :] += np.conj(polvec_f[m]) * F_fi[m, n] * polvec_i[n]
 
-            excInd = 0
+            exc_ind = 0
             if skip_gs:
                 exc_ind = len(gs_list)
             for m, igs in enumerate(gs_list):

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -531,7 +531,7 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
 
         for j, (it, alpha, jt, beta) in enumerate(pol_type):
             ei, ef = dipole_polvec_rixs(thin, thout, phi, alpha, beta,
-                                            scatter_axis, (it, jt))
+                                        scatter_axis, (it, jt))
             if it.lower() == 'isotropic':
                 ei = np.ones(3)/np.sqrt(3)                        # Powder spectrum
             if jt.lower() == 'isotropic':   

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -553,10 +553,10 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
                 for n in range(npol):
                     F_mag[:, :] += np.conj(polvec_f[m]) * F_fi[m, n] * polvec_i[n]
            
-           excInd = 0
-           if (skipGS):
-               excInd = len(gs_list) 
-           for m, igs in enumerate(gs_list):
+            excInd = 0
+            if (skipGS):
+                excInd = len(gs_list) 
+            for m, igs in enumerate(gs_list):
                 for n in range(excInd,len(eval_i)):
                     rixs[i, :, j] += (
                         prob[m] * np.abs(F_mag[n, igs])**2 * gamma_final / np.pi /

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -556,7 +556,7 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
 
             excInd = 0
             if skip_gs:
-                excInd = len(gs_list)
+                exc_ind = len(gs_list)
             for m, igs in enumerate(gs_list):
                 for n in range(excInd, len(eval_i)):
                     rixs[i, :, j] += (

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -534,7 +534,7 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
                                                           scatter_axis, (it, jt))
             if it.lower() == 'isotropic':
                 ei = np.ones(3)/np.sqrt(3)                        # Powder spectrum
-             if jt.lower() == 'isotropic':   
+            if jt.lower() == 'isotropic':   
                 ef = np.ones(3)/np.sqrt(3)
             # dipolar transition
             if npol == 3:

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -418,7 +418,7 @@ def xas_1v1c_py(eval_i, eval_n, trans_op, ominc, *, gamma_c=0.1, thin=1.0, phi=0
 
 def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
                  gamma_c=0.1, gamma_f=0.01, thin=1.0, thout=1.0, phi=0.0,
-                 pol_type=None, gs_list=None, temperature=1.0, scatter_axis=None, skipGS=False):
+                 pol_type=None, gs_list=None, temperature=1.0, scatter_axis=None, skip_gs=False):
     """
     Calculate RIXS for the case of one valence shell plus one core shell with Python solver.
 

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -534,7 +534,7 @@ def rixs_1v1c_py(eval_i, eval_n, trans_op, ominc, eloss, *,
                                         scatter_axis, (it, jt))
             if it.lower() == 'isotropic':
                 ei = np.ones(3)/np.sqrt(3)                        # Powder spectrum
-            if jt.lower() == 'isotropic':   
+            if jt.lower() == 'isotropic':
                 ef = np.ones(3)/np.sqrt(3)
             # dipolar transition
             if npol == 3:


### PR DESCRIPTION
rixs_1v1c_py:
1) added new option for pol_type: 'isotropic'
2) added optional argument skipGS to skip transitions to the ground state (direct peak)