### PR TITLE
Improve NiO example clarifying energies of states. 

### DIFF
--- a/edrixs/utils.py
+++ b/edrixs/utils.py
@@ -314,7 +314,7 @@ def CT_imp_bath(U_dd, Delta, n):
     * :math:`d^{n+1}L^9` has energy :math:`\\Delta`
 
     * :math:`d^{n+2}L^8` has energy :math:`2\\Delta + U_{dd}`
- 
+
     Using this we can write and solve three linear equations to get
     :math:`E_d` and :math:`E_L` the energies of the impurity and bath.
 

--- a/edrixs/utils.py
+++ b/edrixs/utils.py
@@ -380,7 +380,7 @@ def CT_imp_bath_core_hole(U_dd, U_pd, Delta, n):
         Energy of the bath states :math:`E_{Lc}` with a core
         hole
     E_p : float
-        Energy of the core hole state :math:`E_\\textrm{E_p}`
+        Energy of the core hole state :math:`E_p`
 
     Notes
     -----

--- a/edrixs/utils.py
+++ b/edrixs/utils.py
@@ -282,7 +282,7 @@ def CT_imp_bath(U_dd, Delta, n):
     Anderson impurity or charge-transfer model
     appropriate for a :math:`d`-shell transition metal compound.
     Core hole potential effects are omitted from this calculation
-    because one technically performs the ground state
+    because one typically performs the ground state
     diagonalization step leaving out these states.
 
     Parameters

--- a/edrixs/utils.py
+++ b/edrixs/utils.py
@@ -281,6 +281,9 @@ def CT_imp_bath(U_dd, Delta, n):
     Compute energies of the impurity and bath for an
     Anderson impurity or charge-transfer model
     appropriate for a :math:`d`-shell transition metal compound.
+    Core hole potential effects are omitted from this calculation
+    because one technically performs the ground state
+    diagonalization step leaving out these states.
 
     Parameters
     ----------
@@ -311,7 +314,7 @@ def CT_imp_bath(U_dd, Delta, n):
     * :math:`d^{n+1}L^9` has energy :math:`\\Delta`
 
     * :math:`d^{n+2}L^8` has energy :math:`2\\Delta + U_{dd}`
-
+ 
     Using this we can write and solve three linear equations to get
     :math:`E_d` and :math:`E_L` the energies of the impurity and bath.
 
@@ -352,7 +355,10 @@ def CT_imp_bath_core_hole(U_dd, U_pd, Delta, n):
     Compute energies of the impurity and bath for an
     Anderson impurity or charge-transfer model
     appropriate for a :math:`d`-shell transition metal compound
-    with a core hole.
+    with a core hole. Take note that this involves a
+    re-definition of :math:`\\Delta` compared to the
+    :code:`CT_imp_bath` function, which leaves out
+    core hole effects.
 
     Parameters
     ----------

--- a/examples/sphinx/example_03_AIM_XAS.py
+++ b/examples/sphinx/example_03_AIM_XAS.py
@@ -107,7 +107,7 @@ slater = ([F0_dd, F2_dd, F4_dd],  # initial
 # :math:`E_d`, bath energy :math:`E_L`, impurity energy with a core hole
 # :math:`E_{dc}`, bath energy with a core hole :math:`E_{Lc}` and the
 # core hole energy :math:`E_p`. The initial ground state calculation is
-# done in electron language leaving out the core shell. 
+# done in electron language leaving out the core shell.
 Delta = 4.7
 E_d, E_L = edrixs.CT_imp_bath(U_dd, Delta, nd)
 ################################################################################

--- a/examples/sphinx/example_03_AIM_XAS.py
+++ b/examples/sphinx/example_03_AIM_XAS.py
@@ -93,7 +93,7 @@ slater = ([F0_dd, F2_dd, F4_dd],  # initial
 ################################################################################
 # Energy of the bath states
 # ------------------------------------------------------------------------------
-# In the notation used in EDRIXS, :math:`\Delta` sets the energy difference
+# In the notation used here, :math:`\Delta` sets the energy difference
 # between the bath and impurity states. :math:`\Delta` is defined in the atomic
 # limit without crystal field (i.e. in terms of the centers of the impurity and
 # bath states before hybridization is considered) as the energy for a
@@ -106,11 +106,14 @@ slater = ([F0_dd, F2_dd, F4_dd],  # initial
 # for details. We can call these functions to get the impurity energy
 # :math:`E_d`, bath energy :math:`E_L`, impurity energy with a core hole
 # :math:`E_{dc}`, bath energy with a core hole :math:`E_{Lc}` and the
-# core hole energy :math:`E_p`. The
-# :code:`if __name__ == '__main__'` code specifies that this command
-# should only be executed if the file is explicitly run.
+# core hole energy :math:`E_p`. The initial ground state calculation is
+# done in electron language leaving out the core shell. 
 Delta = 4.7
 E_d, E_L = edrixs.CT_imp_bath(U_dd, Delta, nd)
+################################################################################
+# In the intermediate state, we include the core shell and the core hole
+# potential. For this reason, the energies will shift differently to account
+# for this.
 E_dc, E_Lc, E_p = edrixs.CT_imp_bath_core_hole(U_dd, U_dp, Delta, nd)
 message = ("E_d = {:.3f} eV\n"
            "E_L = {:.3f} eV\n"


### PR DESCRIPTION
This updates one of the samples, clarifying a previously fairly confusing element of how the state energies are set. 