### PR TITLE
revise everything charge transfer and Delta

### DIFF
--- a/edrixs/tests/test_utils.py
+++ b/edrixs/tests/test_utils.py
@@ -3,42 +3,47 @@ import edrixs
 
 
 def test_CT_imp_bath():
-    n, Delta, E_L, E_d, U_dd = sympy.symbols('n \\Delta, E_L, E_d, U_{dd}')
+    """CT_imp_bath solves for impurity (E_d) and bath (E_L) energies with no
+    core hole, using two conditions:
+      1. E(d^{n+1} L^9) - E(d^n L^10) = Delta  (charge-transfer energy)
+      2. E(d^n L^10) = 0                         (reference state)
+    The expected closed-form values are verified against the function output.
+    """
+    n = 8
+    Delta = 3
+    U_dd = 2
 
-    Eq1 = sympy.Eq(10*E_L + n*E_d + n*(n - 1)*U_dd/2, rhs=0)
-    Eq2 = sympy.Eq(9*E_L + (n+1)*E_d + (n + 1)*n*U_dd/2, rhs=Delta)
-    Eq3 = sympy.Eq(8*E_L + (n+2)*E_d + (n + 1)*(n + 2)*U_dd/2, rhs=2*Delta + U_dd)
+    E_d_val = (10*Delta - n*(19 + n)*U_dd/2)/(10 + n)
+    E_L_val = n*((1 + n)*U_dd/2-Delta)/(10 + n)
 
-    # from IPython.display import display
-    # display(Eq1, Eq2, Eq3)
-
-    answers = sympy.solve([Eq1, Eq2, Eq3], [E_d, E_L])
-
-    E_d_eq = sympy.Eq(E_d, rhs=answers[E_d])
-    E_L_eq = sympy.Eq(E_L, rhs=answers[E_L])
-
-    # from IPython.display import display
-    # display(E_d_eq, E_L_eq)
-
-    n_val = 8
-    Delta_val = 3
-    U_dd_val = 2
-
-    E_d_val = E_d_eq.rhs.evalf(subs={n: n_val,
-                                     Delta: Delta_val,
-                                     U_dd: U_dd_val})
-
-    E_L_val = E_L_eq.rhs.evalf(subs={n: n_val,
-                                     Delta: Delta_val,
-                                     U_dd: U_dd_val})
-
-    E_d_cal, E_L_cal = edrixs.CT_imp_bath(U_dd_val, Delta_val, n_val)
+    E_d_cal, E_L_cal = edrixs.CT_imp_bath(U_dd, Delta, n)
 
     assert E_d_val == E_d_cal
     assert E_L_val == E_L_cal
 
 
 def test_CT_imp_bath_core_hole():
+    """CT_imp_bath_core_hole solves for E_dc, E_Lc, E_p with a core hole
+    present, using three conditions:
+      1. E(d^n  L^10 p^6) = 0          (reference: full core, no ligand holes)
+      2. E(d^{n+1} L^10 p^5) = 0       (reference: one core hole)
+      3. E(d^{n+1} L^9  p^6) - E(d^n L^10 p^6) = Delta  (same Delta as no-core)
+
+    The test constructs six independent transition-energy equations
+    symbolically (all d^n/d^{n+1}/d^{n+2} transitions for np=5 and np=6),
+    solves them as an overdetermined system, evaluates numerically, and
+    compares against the function.
+
+    With np=6 (full core):
+      Eq1: E(d^n  L^10) = 0
+      Eq2: E(d^{n+1} L^9)  = Delta
+      Eq3: E(d^{n+2} L^8)  = 2*Delta + U_dd
+
+    With np=5 (one core hole):
+      Eq4: E(d^{n+1} L^10) = 0
+      Eq5: E(d^{n+2} L^9)  = Delta + U_dd - U_pd
+      Eq6: E(d^{n+3} L^8)  = 2*Delta + 3*U_dd - 2*U_pd
+    """
     n, Delta, E_Lc, E_dc, E_p, U_dd, U_pd = (
         sympy.symbols('n \\Delta E_{Lc} E_{dc} E_p U_{dd} U_{pd}'))
 
@@ -61,17 +66,11 @@ def test_CT_imp_bath_core_hole():
         5*E_p + 8*E_Lc + (n + 3)*E_dc + (n + 3)*(n + 2)*U_dd/2 + 5*(n + 3)*U_pd,
         rhs=2*Delta + 3*U_dd - 2*U_pd)
 
-    # from IPython.display import display
-    # display(Eq1, Eq2, Eq3, Eq4, Eq5, Eq6)
-
     answer = sympy.solve([Eq1, Eq2, Eq3, Eq4, Eq5, Eq6], [E_dc, E_Lc, E_p])
 
     E_dc_eq = sympy.Eq(E_dc, rhs=answer[E_dc])
     E_Lc_eq = sympy.Eq(E_dc, rhs=answer[E_Lc])
     E_p_eq = sympy.Eq(E_p, rhs=answer[E_p])
-
-    # from IPython.display import display
-    # display(E_dc_eq, E_Lc_eq, E_p_eq)
 
     n_val = 8
     Delta_val = 3
@@ -95,6 +94,9 @@ def test_CT_imp_bath_core_hole():
 
 
 def test_get_atom_data():
+    """get_atom_data returns Hartree-Fock Slater integrals and SOC parameters
+    from the edrixs atomic database. Spot-checks F0, F2, F4 for Ni d^8.
+    """
     res = edrixs.get_atom_data('Ni', v_name='3d', v_noccu=8)
     slater_i = res['slater_i']
     assert slater_i[0][0] == 'F0_11'

--- a/edrixs/utils.py
+++ b/edrixs/utils.py
@@ -8,7 +8,8 @@ __all__ = ['beta_to_kelvin', 'kelvin_to_beta', 'boltz_dist', 'UJ_to_UdJH',
 import numpy as np
 import json
 from importlib.resources import files
-from sympy import Symbol, symbols, solve
+from sympy import symbols, solve
+
 
 def beta_to_kelvin(beta):
     """
@@ -275,17 +276,18 @@ def F0F2F4F6_to_UdJH(F0, F2, F4, F6):
     JH = (286 * F2 + 195 * F4 + 250 * F6) / 6435.0
     return Ud, JH
 
+
 def _master_energy_level_eq():
     """Define master equation relating Coulomb interactions, Delta,
     and energy levels.
 
     Notes
     -----
-    We label the d-electrons $d$, ligand electrons $L$, and the core electrons $p$. 
+    We label the d-electrons $d$, ligand electrons $L$, and the core electrons $p$.
 
     Electron count variables: $n_d$, $n_L$, $n_p$
 
-    Site energy: $E_d$, $E_L$, $E_p$ 
+    Site energy: $E_d$, $E_L$, $E_p$
 
     Coulomb energy between $d$ electrons: $U_{dd}$
 
@@ -293,17 +295,15 @@ def _master_energy_level_eq():
 
     $n$ is the reference number of electrons. e.g. $n=8$ for NiO.
 
-    Note that we will ignore Coulomb interactions in the ligand levels and intra-core hole repulsion. 
+    Note that we will ignore Coulomb interactions in the ligand levels and intra-core hole repulsion.
     """
     n, n_d, n_L, n_p = symbols('n, n_d, n_L, n_p')
     E_d, E_L, E_p = symbols('E_d, E_L, E_p')
     U_dd, U_dp = symbols('U_dd, U_dp')
-    Delta = symbols('Delta')
-    parameters = []
 
-    master = (E_d*n_d + E_L*n_L + E_p*n_p 
-            + n_d*(n_d - 1)*U_dd/2
-            + n_d*n_p*U_dp)
+    master = (E_d*n_d + E_L*n_L + E_p*n_p
+              + n_d*(n_d - 1)*U_dd/2
+              + n_d*n_p*U_dp)
     return master
 
 
@@ -351,6 +351,7 @@ def CT_imp_bath(U_dd, Delta, n):
     S = solve([cond0, cond1], [E_d, E_L])
 
     return float(S[E_d].subs({'U_dd': U_dd})), float(S[E_L].subs({'U_dd': U_dd}))
+
 
 def CT_imp_bath_core_hole(U_dd, U_pd, Delta, n):
     """

--- a/edrixs/utils.py
+++ b/edrixs/utils.py
@@ -8,7 +8,7 @@ __all__ = ['beta_to_kelvin', 'kelvin_to_beta', 'boltz_dist', 'UJ_to_UdJH',
 import numpy as np
 import json
 from importlib.resources import files
-
+from sympy import Symbol, symbols, solve
 
 def beta_to_kelvin(beta):
     """
@@ -275,6 +275,37 @@ def F0F2F4F6_to_UdJH(F0, F2, F4, F6):
     JH = (286 * F2 + 195 * F4 + 250 * F6) / 6435.0
     return Ud, JH
 
+def _master_energy_level_eq():
+    """Define master equation relating Coulomb interactions, Delta,
+    and energy levels.
+
+    Notes
+    -----
+    We label the d-electrons $d$, ligand electrons $L$, and the core electrons $p$. 
+
+    Electron count variables: $n_d$, $n_L$, $n_p$
+
+    Site energy: $E_d$, $E_L$, $E_p$ 
+
+    Coulomb energy between $d$ electrons: $U_{dd}$
+
+    Core hole potential $d$ electrons: $U_{dp}$
+
+    $n$ is the reference number of electrons. e.g. $n=8$ for NiO.
+
+    Note that we will ignore Coulomb interactions in the ligand levels and intra-core hole repulsion. 
+    """
+    n, n_d, n_L, n_p = symbols('n, n_d, n_L, n_p')
+    E_d, E_L, E_p = symbols('E_d, E_L, E_p')
+    U_dd, U_dp = symbols('U_dd, U_dp')
+    Delta = symbols('Delta')
+    parameters = []
+
+    master = (E_d*n_d + E_L*n_L + E_p*n_p 
+            + n_d*(n_d - 1)*U_dd/2
+            + n_d*n_p*U_dp)
+    return master
+
 
 def CT_imp_bath(U_dd, Delta, n):
     """
@@ -303,62 +334,30 @@ def CT_imp_bath(U_dd, Delta, n):
 
     Notes
     -----
-    We credit our approach to Maurits Hakverkort,
-    Heidelberg University.
-    We define the state with a full set of bath orbitals to be zero
-    energy and write the energy levels using the same definitions
-    as [1]_ [2]_ [3]_.
-
-    * :math:`d^{n}L^{10}` has energy :math:`0`
-
-    * :math:`d^{n+1}L^9` has energy :math:`\\Delta`
-
-    * :math:`d^{n+2}L^8` has energy :math:`2\\Delta + U_{dd}`
-
-    Using this we can write and solve three linear equations to get
-    :math:`E_d` and :math:`E_L` the energies of the impurity and bath.
-
-       .. math::
-           \\begin{aligned}
-           10 E_L + n     E_d + n(n-1) \\frac{U_{dd}}{2} &= 0 \\\\
-            9 E_L + (n+1) E_d + (n+1)n \\frac{U_{dd}}{2} &= \\Delta \\\\
-            8 E_L + (n+2) E_d + (n+1)(n+2) \\frac{U_{dd}}{2}
-            &= 2\\Delta + U_{dd}
-           \\end{aligned}
-
-    The solutions are:
-
-       .. math::
-           \\begin{aligned}
-           E_d &=
-           \\frac{10 \\Delta - n (19 +  n) U_{dd}/2}{10 + n}  \\\\
-           E_L &=
-           \\frac{n ((1+n) U_{dd}/2-\\Delta)}{10 + n}
-           \\end{aligned}.
-
-    References
-    ----------
-    .. [1] J. Zaanen, G. A. Sawatzky, and J. W. Allen
-           `Phys. Rev. Lett. 55, 418 (1985) <https://doi.org/10.1103/PhysRevLett.55.418>`_
-    .. [2] Maurits Haverkort et al.,
-           `Phys. Rev. B 85, 165113 (2012) <https://doi.org/10.1103/PhysRevB.85.165113>`_
-    .. [3] A. E. Bocquet et al.,
-           `Phys. Rev. B 53, 1161 (1996) <https://doi.org/10.1103/PhysRevB.53.1161>`_
+    We emit core electrons for initial state calculation which is done
+    by setting $n_p=0$. It is crucial to properly set the energy
+    splitting of $E_d$ and $E_L$ as defined by $\\Delta$.
+    The initial state energy is ill-defined to within an additive factor,
+    so we arbitrarily set the energy with no ligand holes to zero.
+    From there, obtain energies by solving the relevant linear equations.
     """
-    E_d = (10*Delta - n*(19 + n)*U_dd/2)/(10 + n)
-    E_L = n*((1 + n)*U_dd/2-Delta)/(10 + n)
-    return E_d, E_L
+    master = _master_energy_level_eq()
+    E_d, E_L = symbols('E_d E_L')
+    master_no_core = master.subs({'n_p': 0})
+    cond0 = (master_no_core.subs({'n_d': n + 1, 'n_L': 10 - 1})
+             - master_no_core.subs({'n_d': n, 'n_L': 10}) - Delta)
+    cond1 = master_no_core.subs({'n_d': n, 'n_L': 10})
 
+    S = solve([cond0, cond1], [E_d, E_L])
+
+    return float(S[E_d].subs({'U_dd': U_dd})), float(S[E_L].subs({'U_dd': U_dd}))
 
 def CT_imp_bath_core_hole(U_dd, U_pd, Delta, n):
     """
     Compute energies of the impurity and bath for an
     Anderson impurity or charge-transfer model
     appropriate for a :math:`d`-shell transition metal compound
-    with a core hole. Take note that this involves a
-    re-definition of :math:`\\Delta` compared to the
-    :code:`CT_imp_bath` function, which leaves out
-    core hole effects.
+    with a core hole.
 
     Parameters
     ----------
@@ -384,60 +383,38 @@ def CT_imp_bath_core_hole(U_dd, U_pd, Delta, n):
 
     Notes
     -----
-    We credit our approach to Maurits Hakverkort,
-    Heidelberg University.
-    We define the state with a full set of bath orbitals to be zero
-    energy and write the energy levels using the same definitions as
-    [1]_ [2]_ [3]_.
+   For the XAS states, we need to introduce core states into
+   the Hamiltonian and account for their presence when setting
+   energies. It is crucial to define the charge transfer energy
+   in the same way as the intial states, as this affects the way
+   the d and ligand states interact. We do this by imposing the
+   same condition as before just accounting for the presence of
+   core electrons.
 
-    * :math:`2p^5 d^{n}L^{10}` has energy :math:`0`
-
-    * :math:`2p^5 d^{n+1}L^9` has energy :math:`\\Delta + U_{dd} - U_{pd}`
-
-    * :math:`2p^5 d^{n+2}L^8` has energy :math:`2\\Delta + 3 U_{dd} - 2 U_{pd}`
-
-    Using this we can write and solve linear equations to get
-    :math:`E_{dc}`, :math:`E_{Lc}` and :math:`E_p` the energies of the
-    impurity and bath with a core hole and the energy of the core hole.
-
-       .. math::
-           \\begin{aligned}
-               6 E_p + 10 E_{Lc} +  n    E_{dc} + n(n-1) \\frac{U_{dd}}{2}
-               + 6 n     U_{pd} &= 0    \\\\
-               6 E_p +  9 E_{Lc} + (n+1) E_{dc} + (n+1)n \\frac{U_{dd}}{2}
-               + 6 (n+1) U_{pd} &= \\Delta  \\\\
-               6 E_p +  8 E_{Lc} + (n+2) E_{d} + (n+1)(n+2) \\frac{U_{dd}}{2}
-               + 6 (n+2) U_{pd} &= 2 \\Delta+U_{dd} \\\\
-               5 E_p + 10 E_{Lc} + (n+1) E_{d} + (n+1) n \\frac{U_{dd}}{2}
-               + 5 (n+1) U_{pd} &= 0 \\\\
-               5 E_p +  9 E_{Lc} + (n+2) E_{dc} + (n+2)(n+1) \\frac{U_{dd}}{2}
-               + 5 (n+2) U_{pd} &= \\Delta+U_{dd}-U_{pd} \\\\
-               5 E_p +  8 E_{Lc} + (n+3) E_{dc} + (n+3)(n+2) \\frac{U_{dd}}{2}
-               + 5 (n+3) U_{pd} &= 2 \\Delta+3 U_{dd}-2 U_{pd}
-           \\end{aligned}
-
-    The solutions are:
-
-       .. math::
-           \\begin{aligned}
-              E_{dc} &= \\frac{10 \\Delta - n (31+n) \\frac{U_{dd}}{2}-90 U_{pd}}{16+n} \\\\
-              E_{Lc} &= \\frac{(1+n) (n \\frac{U_{dd}}{2}+6*U_{pd})-(6+n) \\Delta}{16+n} \\\\
-              E_p    &= \\frac{10 \\Delta + (1+n)(n\\frac{U_{dd}}{2}-(10+n)*U_{pd}}{16+n}
-           \\end{aligned}
-
-    References
-    ----------
-    .. [1] J. Zaanen, G. A. Sawatzky, and J. W. Allen
-           `Phys. Rev. Lett. 55, 418 (1985) <https://doi.org/10.1103/PhysRevLett.55.418>`_
-    .. [2] Maurits Haverkort et al.,
-           `Phys. Rev. B 85, 165113 (2012) <https://doi.org/10.1103/PhysRevB.85.165113>`_
-    .. [3] A. E. Bocquet et al.,
-           `Phys. Rev. B 53, 1161 (1996) <https://doi.org/10.1103/PhysRevB.53.1161>`_
+    We now have two arbitrary choices. The overall energy is
+    ill-defined to within an additive factor. Since the core states
+    are not hybridized, we can also set those to whatever energy
+    we like (eventually, the core energy will be shifted to match
+    the experiment). Arbitrarily, we pick the same condition as
+    before with $d^n$ no core hole as zero, and we also set the
+    core state energy to make $d^{n+1}$ one core hole zero energy.
+    The relevant energies can be obtained by solving the resulting
+    linear equations.
     """
-    E_dc = (10*Delta - n*(31 + n)*U_dd/2 - 90*U_pd) / (16 + n)
-    E_Lc = ((1 + n)*(n*U_dd/2 + 6*U_pd) - (6 + n)*Delta) / (16 + n)
-    E_p = (10*Delta + (1 + n)*(n*U_dd/2 - (10 + n)*U_pd)) / (16 + n)
-    return E_dc, E_Lc, E_p
+    master = _master_energy_level_eq()
+    E_d, E_L, E_p = symbols('E_d E_L E_p')
+
+    cond0 = (master.subs({'n_d': n + 1, 'n_L': 10 - 1, 'n_p': 6})
+             - master.subs({'n_d': n, 'n_L': 10, 'n_p': 6}) - Delta)
+    cond1 = master.subs({'n_d': n, 'n_L': 10, 'n_p': 6})
+    cond2 = master.subs({'n_d': n + 1, 'n_L': 10, 'n_p': 5})
+
+    S = solve([cond0, cond1, cond2], [E_d, E_L, E_p])
+
+    E_dc = float(S[E_d].subs({'U_dd': U_dd, 'U_dp': U_pd}))
+    E_Lc = float(S[E_L].subs({'U_dd': U_dd, 'U_dp': U_pd}))
+    E_p_val = float(S[E_p].subs({'U_dd': U_dd, 'U_dp': U_pd}))
+    return E_dc, E_Lc, E_p_val
 
 
 def info_atomic_shell():

--- a/examples/sphinx/example_03_AIM_XAS.py
+++ b/examples/sphinx/example_03_AIM_XAS.py
@@ -93,27 +93,31 @@ slater = ([F0_dd, F2_dd, F4_dd],  # initial
 ################################################################################
 # Energy of the bath states
 # ------------------------------------------------------------------------------
-# In the notation used here, :math:`\Delta` sets the energy difference
-# between the bath and impurity states. :math:`\Delta` is defined in the atomic
-# limit without crystal field (i.e. in terms of the centers of the impurity and
-# bath states before hybridization is considered) as the energy for a
-# :math:`d^{n_d} \rightarrow d^{n_d + 1} \underline{L}` transition.
-# Note that as electrons are moved one has to pay energy
-# costs associated with the Coulomb interactions. The
-# energy splitting between the bath and impurity is consequently not simply
-# :math:`\Delta`. One must therefore determine the energies by solving
-# a set of linear equations. See the :ref:`edrixs.utils functions <utils>`
-# for details. We can call these functions to get the impurity energy
-# :math:`E_d`, bath energy :math:`E_L`, impurity energy with a core hole
-# :math:`E_{dc}`, bath energy with a core hole :math:`E_{Lc}` and the
-# core hole energy :math:`E_p`. The initial ground state calculation is
-# done in electron language leaving out the core shell.
+# The charge-transfer energy :math:`\Delta` is defined in the atomic limit
+# (without crystal field or hybridization) as the energy cost of transferring
+# one electron from the bath to the impurity:
+# :math:`\Delta = E(d^{n_d+1}\underline{L}) - E(d^{n_d})`.
+# For NiO we take the value from Ref. [1]_, obtained by fitting theory to
+# experiment.
 Delta = 4.7
+################################################################################
+# Because moving electrons also changes the Coulomb energy, the single-particle
+# level splitting between impurity and bath is not simply :math:`\Delta`.
+# The site energies :math:`E_d` and :math:`E_L` must instead be found by
+# solving a pair of linear equations. We fix the overall energy scale by
+# setting :math:`E(d^{n_d} L^{10}) = 0` as the reference, which together with
+# the definition of :math:`\Delta` uniquely determines :math:`E_d` and
+# :math:`E_L`. The core shell is omitted for the ground-state calculation.
 E_d, E_L = edrixs.CT_imp_bath(U_dd, Delta, nd)
 ################################################################################
-# In the intermediate state, we include the core shell and the core hole
-# potential. For this reason, the energies will shift differently to account
-# for this.
+# For the intermediate (core-hole) state we use the same :math:`\Delta`,
+# which ensures the bath–impurity interaction is defined consistently with
+# the ground state. The core-hole Coulomb potential :math:`U_{dp}` shifts
+# all energies, so we now need two reference conditions: one for the
+# full-core state :math:`E(d^{n_d} L^{10} p^6) = 0` and one for the
+# core-hole state :math:`E(d^{n_d+1} L^{10} p^5) = 0`. These three
+# conditions uniquely determine :math:`E_{dc}`, :math:`E_{Lc}`, and the
+# core-level energy :math:`E_p`.
 E_dc, E_Lc, E_p = edrixs.CT_imp_bath_core_hole(U_dd, U_dp, Delta, nd)
 message = ("E_d = {:.3f} eV\n"
            "E_L = {:.3f} eV\n"


### PR DESCRIPTION
`CT_imp_bath` and `CT_imp_bath_core_hole`: Rewrote both functions using sympy string-based substitution so that what is happening is much clearer to the reader. 

Example 03: Expanded the "Energy of the bath states" section to explain what Δ means and how these are applied alongside arbitrary conventions to determine the energies 