### PR TITLE
Scipy sparse rixs solver and 1v1c wrapper

### DIFF
--- a/edrixs/krylov.py
+++ b/edrixs/krylov.py
@@ -1,0 +1,310 @@
+# -*- coding: utf-8 -*-
+"""Small Krylov/Lanczos utilities.
+
+This module provides low-level routines for evaluating projected resolvents
+and spectral functions from a Lanczos tridiagonal representation.  The
+functions are intentionally independent of any specific spectroscopy solver:
+high-level EDRIXS routines can build problem-specific seed vectors and then use
+these utilities to evaluate the corresponding dynamical response.
+
+The central convention used here is
+
+    G(z) = <psi | (z I - H)^(-1) | psi>,
+
+where ``psi`` is the original, generally unnormalized, Lanczos seed vector.
+With ``z = omega + E0 + i * eta``, the corresponding broadened spectral
+function is
+
+    A(omega) = -Im G(omega + E0 + i eta) / pi.
+"""
+
+import numpy as np
+from scipy.linalg import solve_banded
+from scipy.sparse.linalg import aslinearoperator
+
+__all__ = [
+    "lanczos_tridiagonal",
+    "resolvent_from_tridiag",
+    "spectral_function_from_tridiag",
+]
+
+
+def lanczos_tridiagonal(H, v0, m):
+    """Construct a Lanczos tridiagonal representation of a Hermitian operator.
+
+    Starting from a nonzero seed vector ``v0``, this routine builds an
+    orthonormal Krylov basis for
+
+    ``span{v0, H v0, H**2 v0, ...}``
+
+    and returns the diagonal and off-diagonal elements of the tridiagonal
+    projection of ``H`` in that basis.  The seed vector is normalized
+    internally, but the squared norm of the original seed is returned so that
+    projected spectral weights can be reconstructed.
+
+    Parameters
+    ----------
+    H : array_like, sparse matrix, or scipy.sparse.linalg.LinearOperator
+        Square Hermitian operator to tridiagonalize.  Only matrix-vector
+        products with ``H`` are required.
+    v0 : array_like, shape (n,)
+        Nonzero initial seed vector.  This may be real or complex and is
+        normalized internally.
+    m : int
+        Maximum Krylov dimension.  The actual number of Lanczos vectors may be
+        smaller if a lucky breakdown occurs.  Values larger than the Hilbert
+        space dimension are clipped to ``H.shape[0]``.
+
+    Returns
+    -------
+    alphas : ndarray, shape (k,)
+        Diagonal entries of the Lanczos tridiagonal matrix.
+    betas : ndarray, shape (k - 1,)
+        Off-diagonal entries of the Lanczos tridiagonal matrix.
+    norm : float
+        Squared norm of the original seed vector, ``||v0||**2``.
+
+    Raises
+    ------
+    ValueError
+        If ``H`` is not square, ``m < 1``, ``v0`` is not one-dimensional, the
+        dimensions of ``H`` and ``v0`` are incompatible, or ``v0`` has zero
+        norm.
+
+    Notes
+    -----
+    The returned coefficients define the tridiagonal matrix
+
+    ``T = diag(alphas) + diag(betas, 1) + diag(betas, -1)``.
+
+    For a full Krylov space, the projected resolvent constructed from ``T`` is
+    equivalent to the exact projected resolvent
+
+    ``<v0 | (z I - H)^(-1) | v0>``.
+
+    This implementation does not perform explicit reorthogonalization, which
+    is often sufficient for moderate Krylov dimensions but may need to be
+    revisited for very large calculations or nearly degenerate spectra.
+    """
+    H = aslinearoperator(H)
+
+    if H.shape[0] != H.shape[1]:
+        raise ValueError("H must be a square operator")
+
+    m = int(m)
+    if m < 1:
+        raise ValueError("m must be a positive integer")
+
+    v0 = np.asarray(v0)
+    if v0.ndim != 1:
+        raise ValueError("v0 must be a one-dimensional array")
+    if v0.shape[0] != H.shape[1]:
+        raise ValueError(
+            "dimension mismatch: H has shape {} but v0 has shape {}".format(
+                H.shape, v0.shape
+            )
+        )
+
+    norm = np.linalg.norm(v0)
+    if norm == 0:
+        raise ValueError("v0 must have nonzero norm")
+
+    m = min(m, H.shape[0])
+
+    v = v0.astype(np.result_type(v0.dtype, np.complex128), copy=False) / norm
+    v_old = np.zeros_like(v)
+
+    alphas = np.zeros(m, dtype=float)
+    betas = np.zeros(max(m - 1, 0), dtype=float)
+
+    for j in range(m):
+        w = H @ v
+        if j > 0:
+            w = w - betas[j - 1] * v_old
+
+        alpha = np.vdot(v, w).real
+        alphas[j] = alpha
+        w = w - alpha * v
+
+        if j == m - 1:
+            return alphas, betas, norm**2
+
+        beta = np.linalg.norm(w)
+        if beta == 0:
+            return alphas[: j + 1], betas[:j], norm**2
+
+        betas[j] = beta
+        v_old = v
+        v = w / beta
+
+    return alphas, betas, norm**2
+
+
+def _validate_tridiag(alphas, betas):
+    """Validate and normalize Lanczos tridiagonal coefficient arrays.
+
+    Parameters
+    ----------
+    alphas : array_like, shape (m,)
+        Diagonal entries of the tridiagonal matrix.
+    betas : array_like, shape (m - 1,)
+        Off-diagonal entries of the tridiagonal matrix.
+
+    Returns
+    -------
+    alphas : ndarray, shape (m,)
+        Validated one-dimensional float array.
+    betas : ndarray, shape (m - 1,)
+        Validated one-dimensional float array.
+
+    Raises
+    ------
+    ValueError
+        If either input is not one-dimensional, ``alphas`` is empty, or
+        ``len(betas) != len(alphas) - 1``.
+    """
+    alphas = np.asarray(alphas, dtype=float)
+    betas = np.asarray(betas, dtype=float)
+
+    if alphas.ndim != 1:
+        raise ValueError("alphas must be one-dimensional")
+    if betas.ndim != 1:
+        raise ValueError("betas must be one-dimensional")
+    if len(alphas) == 0:
+        raise ValueError("alphas must contain at least one element")
+    if len(betas) != max(len(alphas) - 1, 0):
+        raise ValueError("betas must have length len(alphas) - 1")
+
+    return alphas, betas
+
+
+def resolvent_from_tridiag(alphas, betas, z, norm=1.0):
+    """Evaluate a projected resolvent from Lanczos tridiagonal coefficients.
+
+    This routine computes
+
+    ``G(z) = norm * [(z I - T)^(-1)]_00``,
+
+    where ``T`` is the tridiagonal Lanczos matrix defined by ``alphas`` and
+    ``betas``.  If ``alphas`` and ``betas`` were generated by
+    :func:`lanczos_tridiagonal` using a seed vector ``psi`` and ``norm`` is the
+    returned squared norm ``||psi||**2``, then ``G(z)`` approximates
+
+    ``<psi | (z I - H)^(-1) | psi>``.
+
+    Parameters
+    ----------
+    alphas : array_like, shape (m,)
+        Diagonal entries of the Lanczos tridiagonal matrix.
+    betas : array_like, shape (m - 1,)
+        Off-diagonal entries of the Lanczos tridiagonal matrix.
+    z : complex or array_like of complex
+        Complex energy argument or array of energy arguments.  The convention
+        is ``z I - H``.  For retarded response functions one typically uses
+        ``z = omega + E0 + 1j * eta`` with ``eta > 0``.
+    norm : float or complex, optional
+        Overall spectral weight.  For coefficients generated by
+        :func:`lanczos_tridiagonal`, this should usually be the returned
+        ``norm`` value, equal to the squared norm of the original seed vector.
+        The default is ``1.0``.
+
+    Returns
+    -------
+    G : complex or ndarray of complex
+        Projected resolvent evaluated at ``z``.  A scalar is returned for
+        scalar input; otherwise the output has the same shape as ``z``.
+
+    Raises
+    ------
+    ValueError
+        If the tridiagonal coefficient arrays have incompatible shapes.
+
+    Notes
+    -----
+    Each value of ``z`` requires solving only a small tridiagonal linear system
+    of size ``len(alphas)``.  The full many-body Hamiltonian is not used by
+    this function.
+    """
+    alphas, betas = _validate_tridiag(alphas, betas)
+
+    z_arr = np.asarray(z, dtype=complex)
+    scalar_input = z_arr.ndim == 0
+    z_flat = z_arr.reshape(-1)
+
+    m = len(alphas)
+    e1 = np.zeros(m, dtype=complex)
+    e1[0] = 1.0
+
+    out = np.empty(z_flat.shape, dtype=complex)
+
+    for iz, zi in enumerate(z_flat):
+        ab = np.zeros((3, m), dtype=complex)
+        ab[1, :] = zi - alphas
+        ab[0, 1:] = -betas
+        ab[2, :-1] = -betas
+
+        y = solve_banded((1, 1), ab, e1)
+        out[iz] = norm * y[0]
+
+    if scalar_input:
+        return out[0]
+    return out.reshape(z_arr.shape)
+
+
+def spectral_function_from_tridiag(alphas, betas, omega, eta, e0=0.0, norm=1.0):
+    """Evaluate a broadened spectral function from Lanczos coefficients.
+
+    This routine evaluates the retarded spectral function
+
+    ``A(omega) = -Im G(omega + e0 + i eta) / pi``,
+
+    where ``G`` is computed by :func:`resolvent_from_tridiag`.  With
+    coefficients generated from a seed vector ``psi = O |g>`` and
+    ``e0 = E_g``, this corresponds to the dynamical correlation function
+
+    ``A(omega) = -Im <psi | (omega + E_g + i eta - H)^(-1) | psi> / pi``.
+
+    Parameters
+    ----------
+    alphas : array_like, shape (m,)
+        Diagonal entries of the Lanczos tridiagonal matrix.
+    betas : array_like, shape (m - 1,)
+        Off-diagonal entries of the Lanczos tridiagonal matrix.
+    omega : float or array_like of float
+        Real frequency or frequency grid at which to evaluate the spectral
+        function.
+    eta : float
+        Positive Lorentzian broadening parameter.
+    e0 : float, optional
+        Energy shift, typically the energy of the initial state.  The default
+        is ``0.0``.
+    norm : float or complex, optional
+        Overall spectral weight.  For coefficients generated by
+        :func:`lanczos_tridiagonal`, this should usually be the returned
+        squared seed norm.  The default is ``1.0``.
+
+    Returns
+    -------
+    spectrum : float or ndarray of float
+        Broadened spectral function evaluated on ``omega``.  A scalar is
+        returned for scalar input; otherwise the output has the same shape as
+        ``omega``.
+
+    Raises
+    ------
+    ValueError
+        If ``eta`` is not positive or the tridiagonal coefficient arrays have
+        incompatible shapes.
+
+    Notes
+    -----
+    The sign convention is consistent with a retarded resolvent
+    ``(omega + e0 + i eta - H)^(-1)``.  The output is positive for positive
+    spectral weights when ``H`` is Hermitian and ``eta > 0``.
+    """
+    if eta <= 0:
+        raise ValueError("eta must be positive")
+
+    z = np.asarray(omega, dtype=float) + e0 + 1j * eta
+    g = resolvent_from_tridiag(alphas, betas, z, norm=norm)
+    return -np.imag(g) / np.pi

--- a/edrixs/manybody_operator_csr.py
+++ b/edrixs/manybody_operator_csr.py
@@ -1,0 +1,144 @@
+import numpy as np
+from collections import defaultdict
+import scipy.sparse as sp
+
+
+def two_fermion_csr(emat, lb, rb=None, tol=1E-10):
+    """
+    Build matrix form of a two-fermionic operator in the given Fock basis,
+
+    .. math::
+
+        <F_{l}|\\sum_{ij}E_{ij}\\hat{f}_{i}^{\\dagger}\\hat{f}_{j}|F_{r}>
+
+    Parameters
+    ----------
+    emat: 2d complex array
+        The impurity matrix.
+    lb: list of array
+        Left fock basis :math:`<F_{l}|`.
+    rb: list of array
+        Right fock basis :math:`|F_{r}>`.
+        rb = lb if rb is None
+    tol: float (default: 1E-10)
+        Only consider the elements of emat that are larger than tol.
+
+    Returns
+    -------
+    hmat: 2d complex array
+        The matrix form of the two-fermionic operator.
+    """
+    if rb is None:
+        rb = lb
+    lb, rb = np.array(lb), np.array(rb)
+    nr, nl, norbs = len(rb), len(lb), len(rb[0])
+    indx = defaultdict(lambda: -1)
+    for i, j in enumerate(lb):
+        indx[tuple(j)] = i
+
+    a1, a2 = np.nonzero(abs(emat) > tol)
+    nonzero = np.stack((a1, a2), axis=-1)
+
+    rows = []
+    cols = []
+    data = []
+
+#    hmat = np.array((nl, nr), dtype=np.complex128)
+    tmp_basis = np.zeros(norbs)
+    for iorb, jorb in nonzero:
+        for icfg in range(nr):
+            tmp_basis[:] = rb[icfg]
+            if tmp_basis[jorb] == 0:
+                continue
+            else:
+                s1 = (-1)**np.count_nonzero(tmp_basis[0:jorb])
+                tmp_basis[jorb] = 0
+            if tmp_basis[iorb] == 1:
+                continue
+            else:
+                s2 = (-1)**np.count_nonzero(tmp_basis[0:iorb])
+                tmp_basis[iorb] = 1
+            jcfg = indx[tuple(tmp_basis)]
+            if jcfg != -1:
+#                hmat[jcfg, icfg] += emat[iorb, jorb] * s1 * s2
+                 rows.append(jcfg)
+                 cols.append(icfg)
+                 data.append(emat[iorb, jorb] * s1 * s2)
+    return sp.coo_matrix((data, (rows, cols)), shape=(nl, nr), dtype=np.complex128).tocsr()
+
+
+def four_fermion_csr(umat, lb, rb=None, tol=1E-10):
+    """
+    Build matrix form of a four-fermionic operator in the given Fock basis,
+
+    .. math::
+
+        <F_l|\\sum_{ij}U_{ijkl}\\hat{f}_{i}^{\\dagger}\\hat{f}_{j}^{\\dagger}
+        \\hat{f}_{k}\\hat{f}_{l}|F_r>
+
+    Parameters
+    ----------
+    umat: 4d complex array
+        The 4 index Coulomb interaction tensor.
+    lb: list of array
+        Left fock basis :math:`<F_{l}|`.
+    rb: list of array
+        Right fock basis :math:`|F_{r}>`.
+        rb = lb if rb is None
+    tol: float (default: 1E-10)
+        Only consider the elements of umat that are larger than tol.
+
+    Returns
+    -------
+    hmat: 2d complex array
+        The matrix form of the four-fermionic operator.
+    """
+    if rb is None:
+        rb = lb
+    lb, rb = np.array(lb), np.array(rb)
+    nr, nl, norbs = len(rb), len(lb), len(rb[0])
+    indx = defaultdict(lambda: -1)
+    for i, j in enumerate(lb):
+        indx[tuple(j)] = i
+
+    a1, a2, a3, a4 = np.nonzero(abs(umat) > tol)
+    nonzero = np.stack((a1, a2, a3, a4), axis=-1)
+
+    rows = []
+    cols = []
+    data = []
+
+    #hmat = np.zeros((nl, nr), dtype=np.complex128)
+    tmp_basis = np.zeros(norbs)
+    for lorb, korb, jorb, iorb in nonzero:
+        if iorb == jorb or korb == lorb:
+            continue
+        for icfg in range(nr):
+            tmp_basis[:] = rb[icfg]
+            if tmp_basis[iorb] == 0:
+                continue
+            else:
+                s1 = (-1)**np.count_nonzero(tmp_basis[0:iorb])
+                tmp_basis[iorb] = 0
+            if tmp_basis[jorb] == 0:
+                continue
+            else:
+                s2 = (-1)**np.count_nonzero(tmp_basis[0:jorb])
+                tmp_basis[jorb] = 0
+            if tmp_basis[korb] == 1:
+                continue
+            else:
+                s3 = (-1)**np.count_nonzero(tmp_basis[0:korb])
+                tmp_basis[korb] = 1
+            if tmp_basis[lorb] == 1:
+                continue
+            else:
+                s4 = (-1)**np.count_nonzero(tmp_basis[0:lorb])
+                tmp_basis[lorb] = 1
+            jcfg = indx[tuple(tmp_basis)]
+            if jcfg != -1:
+                 rows.append(jcfg)
+                 cols.append(icfg)
+                 data.append(umat[lorb, korb, jorb, iorb] * s1 * s2 * s3 * s4)
+#                hmat[jcfg, icfg] += umat[lorb, korb, jorb, iorb] * s1 * s2 * s3 * s4
+    return sp.coo_matrix((data, (rows, cols)), shape=(nl, nr), dtype=np.complex128).tocsr()

--- a/edrixs/manybody_operator_csr.py
+++ b/edrixs/manybody_operator_csr.py
@@ -1,144 +1,340 @@
 import numpy as np
-from collections import defaultdict
 import scipy.sparse as sp
+
+try:
+    from .fock_basis import get_fock_bin_by_N
+except ImportError:  # pragma: no cover
+    from fock_basis import get_fock_bin_by_N
+
+
+class FockBasis:
+    """
+    Integer-encoded Fock basis.
+
+    The occupation pattern is stored as an integer bit string.  Orbital 0 is
+    the most significant bit, matching the ordering used by get_fock_bin_by_N.
+
+    Parameters
+    ----------
+    basis_int : sequence of int
+        Integer-encoded occupation patterns.
+
+    norbs : int
+        Number of spin-orbitals.
+
+    Examples
+    --------
+    If the occupation vector is [1, 1, 0, 0], the encoded integer is
+    int('1100', 2) = 12.
+    """
+
+    def __init__(self, basis_int, norbs):
+        self.basis_int = [int(v) for v in basis_int]
+        self.norbs = int(norbs)
+        self.lookup = {value: i for i, value in enumerate(self.basis_int)}
+
+    def __len__(self):
+        return len(self.basis_int)
+
+    def encode(self, value):
+        """Return the basis position of an integer-encoded Fock state."""
+        return self.lookup[int(value)]
+
+    def decode(self, position):
+        """Return the integer-encoded Fock state at a basis position."""
+        return self.basis_int[position]
+
+
+def get_fock_basis_int(*args):
+    """
+    Get an integer-encoded Fock basis for a multi-shell system.
+
+    Parameters
+    ----------
+    args : ints
+        Pairs of ``number_of_orbitals, occupancy`` for each shell.
+
+    Returns
+    -------
+    basis : FockBasis
+        Integer-encoded Fock basis with ``encode`` and ``decode`` methods.
+    """
+    basis_10 = get_fock_bin_by_N(*args)
+    basis_int = np.array(
+        [int(''.join(map(str, row)), 2) for row in basis_10],
+        dtype=object
+    )
+    norbs = sum(args[0::2])
+    return FockBasis(basis_int, norbs)
+
+
+def _count_occupied_before(state, orb, norbs):
+    """Count occupied orbitals with index smaller than orb."""
+    return (int(state) >> (norbs - orb)).bit_count()
 
 
 def two_fermion_csr(emat, lb, rb=None, tol=1E-10):
     """
-    Build matrix form of a two-fermionic operator in the given Fock basis,
+    Build matrix form of a two-fermion operator in the given Fock basis.
+
+    The operator convention is
 
     .. math::
 
-        <F_{l}|\\sum_{ij}E_{ij}\\hat{f}_{i}^{\\dagger}\\hat{f}_{j}|F_{r}>
+        <F_l|\\sum_{ij} E_{ij} f_i^\\dagger f_j |F_r>.
 
     Parameters
     ----------
-    emat: 2d complex array
-        The impurity matrix.
-    lb: list of array
-        Left fock basis :math:`<F_{l}|`.
-    rb: list of array
-        Right fock basis :math:`|F_{r}>`.
-        rb = lb if rb is None
-    tol: float (default: 1E-10)
-        Only consider the elements of emat that are larger than tol.
+    emat : 2d complex array
+        One-body orbital matrix.
+    lb : FockBasis
+        Left Fock basis :math:`<F_l|`.
+    rb : FockBasis, optional
+        Right Fock basis :math:`|F_r>`.  If None, rb = lb.
+    tol : float, optional
+        Ignore elements of emat with absolute value <= tol.
 
     Returns
     -------
-    hmat: 2d complex array
-        The matrix form of the two-fermionic operator.
+    hmat : scipy.sparse.csr_matrix
+        Sparse many-body representation of the one-body operator.
     """
     if rb is None:
         rb = lb
-    lb, rb = np.array(lb), np.array(rb)
-    nr, nl, norbs = len(rb), len(lb), len(rb[0])
-    indx = defaultdict(lambda: -1)
-    for i, j in enumerate(lb):
-        indx[tuple(j)] = i
 
-    a1, a2 = np.nonzero(abs(emat) > tol)
+    nr = len(rb)
+    nl = len(lb)
+    norbs = lb.norbs
+
+    if rb.norbs != norbs:
+        raise ValueError("left and right Fock bases must have the same norbs")
+
+    a1, a2 = np.nonzero(np.abs(emat) > tol)
     nonzero = np.stack((a1, a2), axis=-1)
 
     rows = []
     cols = []
     data = []
 
-    # hmat = np.array((nl, nr), dtype=np.complex128)
-    tmp_basis = np.zeros(norbs)
     for iorb, jorb in nonzero:
+        bit_j = 1 << (norbs - 1 - jorb)
+        bit_i = 1 << (norbs - 1 - iorb)
+
         for icfg in range(nr):
-            tmp_basis[:] = rb[icfg]
-            if tmp_basis[jorb] == 0:
+            state = rb.decode(icfg)
+
+            if not state & bit_j:
                 continue
-            else:
-                s1 = (-1)**np.count_nonzero(tmp_basis[0:jorb])
-                tmp_basis[jorb] = 0
-            if tmp_basis[iorb] == 1:
+            s1 = (-1) ** _count_occupied_before(state, jorb, norbs)
+            state ^= bit_j
+
+            if state & bit_i:
                 continue
-            else:
-                s2 = (-1)**np.count_nonzero(tmp_basis[0:iorb])
-                tmp_basis[iorb] = 1
-            jcfg = indx[tuple(tmp_basis)]
-            if jcfg != -1:
-                # hmat[jcfg, icfg] += emat[iorb, jorb] * s1 * s2
-                rows.append(jcfg)
-                cols.append(icfg)
-                data.append(emat[iorb, jorb] * s1 * s2)
-    return sp.coo_matrix((data, (rows, cols)), shape=(nl, nr), dtype=np.complex128).tocsr()
+            s2 = (-1) ** _count_occupied_before(state, iorb, norbs)
+            state |= bit_i
+
+            try:
+                jcfg = lb.encode(state)
+            except KeyError:
+                continue
+
+            rows.append(jcfg)
+            cols.append(icfg)
+            data.append(emat[iorb, jorb] * s1 * s2)
+
+    return sp.coo_matrix(
+        (data, (rows, cols)),
+        shape=(nl, nr),
+        dtype=np.complex128
+    ).tocsr()
 
 
 def four_fermion_csr(umat, lb, rb=None, tol=1E-10):
     """
-    Build matrix form of a four-fermionic operator in the given Fock basis,
+    Build matrix form of a four-fermion operator in the given Fock basis.
+
+    The tensor convention is
 
     .. math::
 
-        <F_l|\\sum_{ij}U_{ijkl}\\hat{f}_{i}^{\\dagger}\\hat{f}_{j}^{\\dagger}
-        \\hat{f}_{k}\\hat{f}_{l}|F_r>
+        <F_l|\\sum_{lkji} U_{lkji}
+        f_l^\\dagger f_k^\\dagger f_j f_i |F_r>.
 
     Parameters
     ----------
-    umat: 4d complex array
-        The 4 index Coulomb interaction tensor.
-    lb: list of array
-        Left fock basis :math:`<F_{l}|`.
-    rb: list of array
-        Right fock basis :math:`|F_{r}>`.
-        rb = lb if rb is None
-    tol: float (default: 1E-10)
-        Only consider the elements of umat that are larger than tol.
+    umat : 4d complex array
+        Coulomb tensor with entries ``umat[lorb, korb, jorb, iorb]``.
+    lb : FockBasis
+        Left Fock basis :math:`<F_l|`.
+    rb : FockBasis, optional
+        Right Fock basis :math:`|F_r>`.  If None, rb = lb.
+    tol : float, optional
+        Ignore elements of umat with absolute value <= tol.
 
     Returns
     -------
-    hmat: 2d complex array
-        The matrix form of the four-fermionic operator.
+    hmat : scipy.sparse.csr_matrix
+        Sparse many-body representation of the two-body operator.
     """
     if rb is None:
         rb = lb
-    lb, rb = np.array(lb), np.array(rb)
-    nr, nl, norbs = len(rb), len(lb), len(rb[0])
-    indx = defaultdict(lambda: -1)
-    for i, j in enumerate(lb):
-        indx[tuple(j)] = i
 
-    a1, a2, a3, a4 = np.nonzero(abs(umat) > tol)
+    nr = len(rb)
+    nl = len(lb)
+    norbs = lb.norbs
+
+    if rb.norbs != norbs:
+        raise ValueError("left and right Fock bases must have the same norbs")
+
+    a1, a2, a3, a4 = np.nonzero(np.abs(umat) > tol)
     nonzero = np.stack((a1, a2, a3, a4), axis=-1)
 
     rows = []
     cols = []
     data = []
 
-    # hmat = np.zeros((nl, nr), dtype=np.complex128)
-    tmp_basis = np.zeros(norbs)
     for lorb, korb, jorb, iorb in nonzero:
         if iorb == jorb or korb == lorb:
             continue
+
+        bit_i = 1 << (norbs - 1 - iorb)
+        bit_j = 1 << (norbs - 1 - jorb)
+        bit_k = 1 << (norbs - 1 - korb)
+        bit_l = 1 << (norbs - 1 - lorb)
+
         for icfg in range(nr):
-            tmp_basis[:] = rb[icfg]
-            if tmp_basis[iorb] == 0:
+            state = rb.decode(icfg)
+
+            if not state & bit_i:
                 continue
-            else:
-                s1 = (-1)**np.count_nonzero(tmp_basis[0:iorb])
-                tmp_basis[iorb] = 0
-            if tmp_basis[jorb] == 0:
+            s1 = (-1) ** _count_occupied_before(state, iorb, norbs)
+            state ^= bit_i
+
+            if not state & bit_j:
                 continue
-            else:
-                s2 = (-1)**np.count_nonzero(tmp_basis[0:jorb])
-                tmp_basis[jorb] = 0
-            if tmp_basis[korb] == 1:
+            s2 = (-1) ** _count_occupied_before(state, jorb, norbs)
+            state ^= bit_j
+
+            if state & bit_k:
                 continue
-            else:
-                s3 = (-1)**np.count_nonzero(tmp_basis[0:korb])
-                tmp_basis[korb] = 1
-            if tmp_basis[lorb] == 1:
+            s3 = (-1) ** _count_occupied_before(state, korb, norbs)
+            state |= bit_k
+
+            if state & bit_l:
                 continue
-            else:
-                s4 = (-1)**np.count_nonzero(tmp_basis[0:lorb])
-                tmp_basis[lorb] = 1
-            jcfg = indx[tuple(tmp_basis)]
-            if jcfg != -1:
-                rows.append(jcfg)
-                cols.append(icfg)
-                data.append(umat[lorb, korb, jorb, iorb] * s1 * s2 * s3 * s4)
-                # hmat[jcfg, icfg] += umat[lorb, korb, jorb, iorb] * s1 * s2 * s3 * s4
-    return sp.coo_matrix((data, (rows, cols)), shape=(nl, nr), dtype=np.complex128).tocsr()
+            s4 = (-1) ** _count_occupied_before(state, lorb, norbs)
+            state |= bit_l
+
+            try:
+                jcfg = lb.encode(state)
+            except KeyError:
+                continue
+
+            rows.append(jcfg)
+            cols.append(icfg)
+            data.append(umat[lorb, korb, jorb, iorb] * s1 * s2 * s3 * s4)
+
+    return sp.coo_matrix(
+        (data, (rows, cols)),
+        shape=(nl, nr),
+        dtype=np.complex128
+    ).tocsr()
+
+
+def four_fermion_csr_auto(umat, basis, rb=None, tol=1E-10):
+    """Dispatch four-fermion construction based on dense or sparse U format."""
+    if sp.issparse(umat):
+        return _four_fermion_csr_from_sparse_umat(umat, basis, rb=rb, tol=tol)
+
+    return four_fermion_csr(umat, basis, rb=rb, tol=tol)
+
+
+def _four_fermion_csr_from_sparse_umat(umat, lb, rb=None, tol=1E-10):
+    """
+    Build a four-fermion many-body operator from sparse flattened U.
+
+    The sparse U matrix must have shape (norbs*norbs, norbs*norbs), with
+
+        row = lorb * norbs + korb
+        col = jorb * norbs + iorb
+
+    representing tensor entries umat[lorb, korb, jorb, iorb].
+    """
+    if rb is None:
+        rb = lb
+
+    nr = len(rb)
+    nl = len(lb)
+    norbs = lb.norbs
+
+    if rb.norbs != norbs:
+        raise ValueError("left and right Fock bases must have the same norbs")
+
+    expected_shape = (norbs * norbs, norbs * norbs)
+    if umat.shape != expected_shape:
+        raise ValueError(
+            "sparse umat has shape {}, expected {}".format(
+                umat.shape, expected_shape
+            )
+        )
+
+    umat = umat.tocoo()
+
+    rows = []
+    cols = []
+    data = []
+
+    for row, col, val in zip(umat.row, umat.col, umat.data):
+        if abs(val) <= tol:
+            continue
+
+        lorb = row // norbs
+        korb = row % norbs
+        jorb = col // norbs
+        iorb = col % norbs
+
+        if iorb == jorb or korb == lorb:
+            continue
+
+        bit_i = 1 << (norbs - 1 - iorb)
+        bit_j = 1 << (norbs - 1 - jorb)
+        bit_k = 1 << (norbs - 1 - korb)
+        bit_l = 1 << (norbs - 1 - lorb)
+
+        for icfg in range(nr):
+            state = rb.decode(icfg)
+
+            if not state & bit_i:
+                continue
+            s1 = (-1) ** (int(state) >> (norbs - iorb)).bit_count()
+            state ^= bit_i
+
+            if not state & bit_j:
+                continue
+            s2 = (-1) ** (int(state) >> (norbs - jorb)).bit_count()
+            state ^= bit_j
+
+            if state & bit_k:
+                continue
+            s3 = (-1) ** (int(state) >> (norbs - korb)).bit_count()
+            state |= bit_k
+
+            if state & bit_l:
+                continue
+            s4 = (-1) ** (int(state) >> (norbs - lorb)).bit_count()
+            state |= bit_l
+
+            try:
+                jcfg = lb.encode(state)
+            except KeyError:
+                continue
+
+            rows.append(jcfg)
+            cols.append(icfg)
+            data.append(val * s1 * s2 * s3 * s4)
+
+    return sp.coo_matrix(
+        (data, (rows, cols)),
+        shape=(nl, nr),
+        dtype=np.complex128
+    ).tocsr()

--- a/edrixs/manybody_operator_csr.py
+++ b/edrixs/manybody_operator_csr.py
@@ -43,7 +43,7 @@ def two_fermion_csr(emat, lb, rb=None, tol=1E-10):
     cols = []
     data = []
 
-#    hmat = np.array((nl, nr), dtype=np.complex128)
+    # hmat = np.array((nl, nr), dtype=np.complex128)
     tmp_basis = np.zeros(norbs)
     for iorb, jorb in nonzero:
         for icfg in range(nr):
@@ -60,10 +60,10 @@ def two_fermion_csr(emat, lb, rb=None, tol=1E-10):
                 tmp_basis[iorb] = 1
             jcfg = indx[tuple(tmp_basis)]
             if jcfg != -1:
-#                hmat[jcfg, icfg] += emat[iorb, jorb] * s1 * s2
-                 rows.append(jcfg)
-                 cols.append(icfg)
-                 data.append(emat[iorb, jorb] * s1 * s2)
+                # hmat[jcfg, icfg] += emat[iorb, jorb] * s1 * s2
+                rows.append(jcfg)
+                cols.append(icfg)
+                data.append(emat[iorb, jorb] * s1 * s2)
     return sp.coo_matrix((data, (rows, cols)), shape=(nl, nr), dtype=np.complex128).tocsr()
 
 
@@ -108,7 +108,7 @@ def four_fermion_csr(umat, lb, rb=None, tol=1E-10):
     cols = []
     data = []
 
-    #hmat = np.zeros((nl, nr), dtype=np.complex128)
+    # hmat = np.zeros((nl, nr), dtype=np.complex128)
     tmp_basis = np.zeros(norbs)
     for lorb, korb, jorb, iorb in nonzero:
         if iorb == jorb or korb == lorb:
@@ -137,8 +137,8 @@ def four_fermion_csr(umat, lb, rb=None, tol=1E-10):
                 tmp_basis[lorb] = 1
             jcfg = indx[tuple(tmp_basis)]
             if jcfg != -1:
-                 rows.append(jcfg)
-                 cols.append(icfg)
-                 data.append(umat[lorb, korb, jorb, iorb] * s1 * s2 * s3 * s4)
-#                hmat[jcfg, icfg] += umat[lorb, korb, jorb, iorb] * s1 * s2 * s3 * s4
+                rows.append(jcfg)
+                cols.append(icfg)
+                data.append(umat[lorb, korb, jorb, iorb] * s1 * s2 * s3 * s4)
+                # hmat[jcfg, icfg] += umat[lorb, korb, jorb, iorb] * s1 * s2 * s3 * s4
     return sp.coo_matrix((data, (rows, cols)), shape=(nl, nr), dtype=np.complex128).tocsr()

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -1,10 +1,14 @@
-__all__ = ['ed_1v1c_py', 'xas_1v1c_py', 'rixs_1v1c_py',
+__all__ = ['Ops_1v1c_scipy','ed_krylov_scipy', 'rixs_krylov_scipy',
+           'ed_1v1c_py', 'xas_1v1c_py', 'rixs_1v1c_py',
            'ed_1v1c_fort', 'xas_1v1c_fort', 'rixs_1v1c_fort',
            'ed_2v1c_fort', 'xas_2v1c_fort', 'rixs_2v1c_fort',
            'ed_siam_fort', 'xas_siam_fort', 'rixs_siam_fort']
 
 import numpy as np
 import scipy
+from scipy.sparse.linalg import LinearOperator, aslinearoperator, lobpcg, gmres
+import inspect
+import warnings
 
 from .iostream import (
     write_tensor, write_emat, write_umat, write_config, read_poles_from_file
@@ -23,6 +27,639 @@ from .utils import info_atomic_shell, slater_integrals_name, boltz_dist
 from .rixs_utils import scattering_mat
 from .plot_spectrum import get_spectra_from_poles, merge_pole_dicts
 from .soc import atom_hsoc
+from .krylov import lanczos_tridiagonal
+from .manybody_operator_csr import two_fermion_csr, four_fermion_csr
+
+def Ops_1v1c_scipy(shell_name, *, shell_level=None, v_soc=None, c_soc=0,
+                v_noccu=1, slater=None, ext_B=None, on_which='spin',
+                v_cfmat=None, v_othermat=None, loc_axis=None, verbose=0,
+                csr=True):
+    """
+    Assemble sparse one-valence-one-core RIXS operators for Krylov solvers.
+
+    This routine mirrors the model-construction part of ed_1v1c_py, but it does
+    not diagonalize either Hamiltonian and it does not transform transition
+    operators to an eigenbasis.
+
+    Returns
+    -------
+    hmat_i : scipy.sparse.linalg.LinearOperator
+        Initial/final many-body Hamiltonian in the initial Fock basis.
+
+    hmat_n : scipy.sparse.linalg.LinearOperator
+        Intermediate many-body Hamiltonian in the intermediate Fock basis.
+
+    trans_ops : list of scipy.sparse.linalg.LinearOperator
+        Transition operators in the many-body basis.  Each operator maps from
+        the initial Hilbert space to the intermediate Hilbert space and has
+        shape (dim_n, dim_i).  The list has length 3 for dipole transitions or
+        length 5 for quadrupole transitions.
+    """
+    if csr is not True:
+        raise ValueError("Ops_1v1c_sp always builds sparse CSR operators; use csr=True")
+
+    print("edrixs >>> Building sparse 1v1c operators ...")
+
+    v_name_options = ['s', 'p', 't2g', 'd', 'f']
+    c_name_options = ['s', 'p', 'p12', 'p32', 't2g', 'd', 'd32', 'd52',
+                      'f', 'f52', 'f72']
+
+    v_name = shell_name[0].strip()
+    c_name = shell_name[1].strip()
+
+    if v_name not in v_name_options:
+        raise Exception("NOT supported type of valence shell: ", v_name)
+    if c_name not in c_name_options:
+        raise Exception("NOT supported type of core shell: ", c_name)
+
+    info_shell = info_atomic_shell()
+
+    v_orbl = info_shell[v_name][0]
+    v_norb = info_shell[v_name][1]
+    c_norb = info_shell[c_name][1]
+    ntot = v_norb + c_norb
+
+    emat_i = np.zeros((ntot, ntot), dtype=complex)
+    emat_n = np.zeros((ntot, ntot), dtype=complex)
+
+    # Coulomb interaction.
+    slater_name = slater_integrals_name((v_name, c_name), ('v', 'c'))
+    nslat = len(slater_name)
+
+    slater_i = np.zeros(nslat, dtype=float)
+    slater_n = np.zeros(nslat, dtype=float)
+
+    if slater is not None:
+        if nslat > len(slater[0]):
+            slater_i[0:len(slater[0])] = slater[0]
+        else:
+            slater_i[:] = slater[0][0:nslat]
+
+        if nslat > len(slater[1]):
+            slater_n[0:len(slater[1])] = slater[1]
+        else:
+            slater_n[:] = slater[1][0:nslat]
+
+    print()
+    print("    Summary of Slater integrals:")
+    print("    ------------------------------")
+    print("    Terms,   Initial Hamiltonian,  Intermediate Hamiltonian")
+    for i in range(nslat):
+        print("    ", slater_name[i], ":  {:20.10f}{:20.10f}".format(
+            slater_i[i], slater_n[i]
+        ))
+    print()
+
+    case = v_name + c_name
+    umat_i = get_umat_slater(case, *slater_i)
+    umat_n = get_umat_slater(case, *slater_n)
+
+    if verbose > 0:
+        write_umat(umat_i, 'coulomb_i.in')
+        write_umat(umat_n, 'coulomb_n.in')
+
+    # Spin-orbit coupling.
+    if v_soc is not None:
+        emat_i[0:v_norb, 0:v_norb] += atom_hsoc(v_name, v_soc[0])
+        emat_n[0:v_norb, 0:v_norb] += atom_hsoc(v_name, v_soc[1])
+
+    # For split core shells such as p12/p32, d32/d52, f52/f72, the SOC is
+    # already encoded by the shell choice.
+    if c_name in ['p', 'd', 'f']:
+        emat_n[v_norb:ntot, v_norb:ntot] += atom_hsoc(c_name, c_soc)
+
+    # Crystal field and additional one-body terms.
+    if v_cfmat is not None:
+        emat_i[0:v_norb, 0:v_norb] += np.asarray(v_cfmat)
+        emat_n[0:v_norb, 0:v_norb] += np.asarray(v_cfmat)
+
+    if v_othermat is not None:
+        emat_i[0:v_norb, 0:v_norb] += np.asarray(v_othermat)
+        emat_n[0:v_norb, 0:v_norb] += np.asarray(v_othermat)
+
+    # Shell levels.
+    if shell_level is not None:
+        emat_i[0:v_norb, 0:v_norb] += np.eye(v_norb) * shell_level[0]
+        emat_i[v_norb:ntot, v_norb:ntot] += np.eye(c_norb) * shell_level[1]
+
+        emat_n[0:v_norb, 0:v_norb] += np.eye(v_norb) * shell_level[0]
+        emat_n[v_norb:ntot, v_norb:ntot] += np.eye(c_norb) * shell_level[1]
+
+    # External field on valence shell.
+    if v_name == 't2g':
+        lx, ly, lz = get_lx(1, True), get_ly(1, True), get_lz(1, True)
+        sx, sy, sz = get_sx(1), get_sy(1), get_sz(1)
+        lx, ly, lz = -lx, -ly, -lz
+    else:
+        lx, ly, lz = get_lx(v_orbl, True), get_ly(v_orbl, True), get_lz(v_orbl, True)
+        sx, sy, sz = get_sx(v_orbl), get_sy(v_orbl), get_sz(v_orbl)
+
+    if ext_B is not None:
+        if on_which.strip() == 'spin':
+            zeeman = ext_B[0] * (2 * sx) + ext_B[1] * (2 * sy) + ext_B[2] * (2 * sz)
+        elif on_which.strip() == 'orbital':
+            zeeman = ext_B[0] * lx + ext_B[1] * ly + ext_B[2] * lz
+        elif on_which.strip() == 'both':
+            zeeman = (
+                ext_B[0] * (lx + 2 * sx)
+                + ext_B[1] * (ly + 2 * sy)
+                + ext_B[2] * (lz + 2 * sz)
+            )
+        else:
+            raise Exception("Unknown value of on_which", on_which)
+
+        emat_i[0:v_norb, 0:v_norb] += zeeman
+        emat_n[0:v_norb, 0:v_norb] += zeeman
+
+    if verbose > 0:
+        write_emat(emat_i, 'hopping_i.in')
+        write_emat(emat_n, 'hopping_n.in')
+
+    # Fock bases.
+    basis_i = get_fock_bin_by_N(v_norb, v_noccu, c_norb, c_norb)
+    basis_n = get_fock_bin_by_N(v_norb, v_noccu + 1, c_norb, c_norb - 1)
+
+    ncfg_i = len(basis_i)
+    ncfg_n = len(basis_n)
+
+    print("edrixs >>> Dimension of the initial Hamiltonian: ", ncfg_i)
+    print("edrixs >>> Dimension of the intermediate Hamiltonian: ", ncfg_n)
+
+    # Sparse many-body Hamiltonians in the Fock bases.
+    print("edrixs >>> Building sparse many-body Hamiltonians ...")
+
+    hmat_i_sp = two_fermion_csr(emat_i, basis_i, basis_i)
+    hmat_i_sp = hmat_i_sp + four_fermion_csr(umat_i, basis_i)
+
+    hmat_n_sp = two_fermion_csr(emat_n, basis_n, basis_n)
+    hmat_n_sp = hmat_n_sp + four_fermion_csr(umat_n, basis_n)
+
+    hmat_i_sp = hmat_i_sp.tocsr()
+    hmat_n_sp = hmat_n_sp.tocsr()
+
+    print("edrixs >>> Done !")
+
+    # Transition operators in local coordinates, rotated to global coordinates.
+    if loc_axis is not None:
+        local_axis = np.asarray(loc_axis)
+    else:
+        local_axis = np.eye(3)
+
+    tmp = get_trans_oper(case)
+    npol, n, m = tmp.shape
+    tmp_g = np.zeros((npol, n, m), dtype=complex)
+
+    if npol == 3:
+        for i in range(3):
+            for j in range(3):
+                tmp_g[i] += local_axis[i, j] * tmp[j]
+    elif npol == 5:
+        alpha, beta, gamma = rmat_to_euler(local_axis)
+        wignerD = get_wigner_dmat(4, alpha, beta, gamma)
+        rotmat = np.dot(
+            np.dot(tmat_r2c('d'), wignerD),
+            np.conj(np.transpose(tmat_r2c('d')))
+        )
+        for i in range(5):
+            for j in range(5):
+                tmp_g[i] += rotmat[i, j] * tmp[j]
+    else:
+        raise Exception("Have NOT implemented this case: ", npol)
+
+    print("edrixs >>> Building sparse transition operators ...")
+
+    trans_ops_sp = []
+    for i in range(npol):
+        trans_mat = np.zeros((ntot, ntot), dtype=complex)
+        trans_mat[0:v_norb, v_norb:ntot] = tmp_g[i]
+        trans_ops_sp.append(
+            two_fermion_csr(trans_mat, basis_n, basis_i).tocsr()
+        )
+
+    print("edrixs >>> Sparse operator assembly Done !")
+
+    hmat_i = aslinearoperator(hmat_i_sp)
+    hmat_n = aslinearoperator(hmat_n_sp)
+    trans_ops = [aslinearoperator(T) for T in trans_ops_sp]
+
+    return hmat_i, hmat_n, trans_ops
+
+def ed_krylov_scipy(hmat_i, num_gs=1, blocksize=None, *,
+                    tol=1e-10, maxiter=200,
+                    seed=None, initial_guess=None, suppress_lobpcg_warnings=True):
+    """
+    Compute the lowest retained initial-state eigenpairs using SciPy LOBPCG.
+
+    This routine is intended to prepare the low-energy initial states used by
+    rixs_krylov_scipy. It diagonalizes only the initial/final Hamiltonian
+    hmat_i and returns the lowest num_gs eigenpairs.
+
+    Parameters
+    ----------
+    hmat_i : sparse matrix or scipy.sparse.linalg.LinearOperator
+        Initial/final Hamiltonian. It must be square and Hermitian.
+
+    num_gs : int, optional
+        Number of lowest-energy initial states to retain and return.
+
+    blocksize : int or None, optional
+        Number of eigenpairs requested internally from LOBPCG. If None, it is
+        set to num_gs. If larger than num_gs, extra eigenpairs are computed
+        and then discarded. This can help when low-energy degeneracies are
+        expected or when a larger block improves convergence.
+
+    tol : float, optional
+        LOBPCG convergence tolerance.
+
+    maxiter : int, optional
+        Maximum number of LOBPCG iterations.
+
+    seed : int or None, optional
+        Random seed used to construct the initial block if initial_guess is not
+        provided.
+
+    initial_guess : ndarray or None, optional
+        Initial approximation block X for LOBPCG. If provided, it must have
+        shape ``(dim_i, blocksize)``.
+
+    Returns
+    -------
+    eval_i : ndarray
+        Lowest retained eigenvalues, shape ``(num_gs,)``.
+
+    evec_i : ndarray
+        Corresponding eigenvectors, shape ``(dim_i, num_gs)``.
+    """
+    hmat_i = aslinearoperator(hmat_i)
+
+    if hmat_i.shape[0] != hmat_i.shape[1]:
+        raise ValueError("hmat_i must be square")
+
+    num_gs = int(num_gs)
+    if num_gs < 1:
+        raise ValueError("num_gs must be a positive integer")
+
+    dim_i = hmat_i.shape[0]
+
+    if blocksize is None:
+        blocksize = num_gs
+
+    blocksize = int(blocksize)
+
+    if blocksize < num_gs:
+        raise ValueError("blocksize must be greater than or equal to num_gs")
+
+    if blocksize > dim_i:
+        raise ValueError("blocksize cannot exceed hmat_i.shape[0]")
+
+    if initial_guess is None:
+        rng = np.random.default_rng(seed)
+        X = rng.normal(size=(dim_i, blocksize))
+    else:
+        X = np.asarray(initial_guess)
+        if X.shape != (dim_i, blocksize):
+            raise ValueError(
+                "initial_guess must have shape {}, got {}".format(
+                    (dim_i, blocksize), X.shape
+                )
+            )
+
+    if suppress_lobpcg_warnings:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=UserWarning,
+                message=r"Exited at iteration .*",
+            )
+            warnings.filterwarnings(
+                "ignore",
+                category=UserWarning,
+                message=r"Exited postprocessing .*",
+            )
+
+            evals, evecs = lobpcg(
+                hmat_i,
+                X,
+                largest=False,
+                tol=tol,
+                maxiter=maxiter,
+            )
+    else:
+        evals, evecs = lobpcg(
+            hmat_i,
+            X,
+            largest=False,
+            tol=tol,
+            maxiter=maxiter,
+        )
+
+    order = np.argsort(evals)
+
+    eval_i = np.asarray(evals)[order[:num_gs]]
+    evec_i = np.asarray(evecs)[:, order[:num_gs]]
+
+    return eval_i, evec_i
+
+def rixs_krylov_scipy(eval_i, evec_i, hmat_i, hmat_n, trans_op, ominc, eloss, *,
+                      gamma_c=0.1, gamma_f=0.01, thin=1.0, thout=1.0, phi=0.0,
+                      pol_type=None, temperature=1.0, scatter_axis=None,
+                      skip_gs=False, nkryl=200, linsys_tol=1e-9,
+                      linsys_maxiter=50000, linsys_restart=200, return_poles=False):
+    """
+    Calculate RIXS spectra with a SciPy Krylov correction-vector solver.
+
+    This routine assumes that eval_i and evec_i contain only the kept initial
+    states. It does not use gs_list.
+
+    hmat_i, hmat_n, and every element of trans_op are converted with
+    scipy.sparse.linalg.aslinearoperator. The transition operators must provide
+    an adjoint action, because the absorption step uses T @ v and the emission
+    step uses T.H @ v.
+
+    Parameters
+    ----------
+    eval_i : 1d array
+        Energies of the kept initial states.
+
+    evec_i : 2d array
+        Kept initial-state eigenvectors in the basis of hmat_i.
+        Column i corresponds to eval_i[i].
+
+    hmat_i : sparse matrix or LinearOperator
+        Initial/final Hamiltonian.
+
+    hmat_n : sparse matrix or LinearOperator
+        Intermediate-state Hamiltonian.
+
+    trans_op : list
+        List of transition operators. Each operator maps the initial/final
+        Hilbert space to the intermediate Hilbert space and must have shape
+        (dim_n, dim_i). For dipole transitions this list has length 3;
+        for quadrupole transitions it has length 5.
+
+    ominc : 1d array
+        Incident photon energies.
+
+    eloss : 1d array
+        Energy-loss grid.
+
+    Returns
+    -------
+    rixs : 3d array
+        RIXS spectra with shape (len(ominc), len(eloss), len(pol_type)).
+
+    poles : list, optional
+        Returned only if return_poles is True. Nested list of pole dictionaries
+        with shape (len(ominc), len(pol_type)).
+    """
+    print("edrixs >>> Running Krylov RIXS ... ")
+
+    eval_i = np.asarray(eval_i, dtype=float)
+    evec_i = np.asarray(evec_i, dtype=complex)
+    ominc = np.asarray(ominc, dtype=float)
+    eloss = np.asarray(eloss, dtype=float)
+
+    hmat_i = aslinearoperator(hmat_i)
+    hmat_n = aslinearoperator(hmat_n)
+    trans_op = [aslinearoperator(T) for T in trans_op]
+
+    if hmat_i.shape[0] != hmat_i.shape[1]:
+        raise ValueError("hmat_i must be square")
+    if hmat_n.shape[0] != hmat_n.shape[1]:
+        raise ValueError("hmat_n must be square")
+    if evec_i.ndim != 2:
+        raise ValueError("evec_i must be a two-dimensional array")
+    if len(eval_i) != evec_i.shape[1]:
+        raise ValueError("len(eval_i) must equal evec_i.shape[1]")
+    if evec_i.shape[0] != hmat_i.shape[0]:
+        raise ValueError("evec_i.shape[0] must equal hmat_i.shape[0]")
+
+    dim_i = hmat_i.shape[0]
+    dim_n = hmat_n.shape[0]
+    ntrans = len(trans_op)
+
+    if ntrans not in (3, 5):
+        raise ValueError("len(trans_op) must be 3 for dipole or 5 for quadrupole transitions")
+
+    for i, T in enumerate(trans_op):
+        if T.shape != (dim_n, dim_i):
+            raise ValueError(
+                "trans_op[{}] has shape {}, expected {}".format(
+                    i, T.shape, (dim_n, dim_i)
+                )
+            )
+        _check_adjoint_action(T, "trans_op[{}]".format(i))
+
+    if pol_type is None:
+        pol_type = [('linear', 0, 'linear', 0)]
+
+    if scatter_axis is None:
+        scatter_axis = np.eye(3)
+    else:
+        scatter_axis = np.asarray(scatter_axis, dtype=float)
+
+    n_ominc = len(ominc)
+    n_eloss = len(eloss)
+    n_init = len(eval_i)
+    n_pol = len(pol_type)
+
+    gamma_core = _expand_broadening(gamma_c, n_ominc, "gamma_c")
+    gamma_final = _expand_broadening(gamma_f, n_eloss, "gamma_f")
+
+    rixs = np.zeros((n_ominc, n_eloss, n_pol), dtype=float)
+    poles_all = [[None for _ in range(n_pol)] for _ in range(n_ominc)]
+
+    trans_op_H = [T.H for T in trans_op]
+
+    for iom, omega in enumerate(ominc):
+        for ipol, (it, alpha, jt, beta) in enumerate(pol_type):
+            polvec_i, polvec_f = _rixs_polarization_vectors(
+                ntrans, thin, thout, phi, it, alpha, jt, beta, scatter_axis
+            )
+
+            poles_dict = {
+                'npoles': [],
+                'eigval': [],
+                'norm': [],
+                'alpha': [],
+                'beta': []
+            }
+
+            for istate in range(n_init):
+                rhs = _apply_linear_combination(
+                    trans_op, polvec_i, evec_i[:, istate]
+                )
+
+                rec = _rixs_krylov_one_contribution_scipy(
+                    hmat_i=hmat_i,
+                    hmat_n=hmat_n,
+                    trans_op_H=trans_op_H,
+                    polvec_f=polvec_f,
+                    eval_i=eval_i,
+                    evec_i=evec_i,
+                    istate=istate,
+                    omega=omega,
+                    gamma_c=gamma_core[iom],
+                    rhs=rhs,
+                    skip_gs=skip_gs,
+                    nkryl=nkryl,
+                    linsys_tol=linsys_tol,
+                    linsys_maxiter=linsys_maxiter,
+                    linsys_restart=linsys_restart
+                )
+
+                poles_dict['npoles'].append(rec['npoles'])
+                poles_dict['eigval'].append(rec['eigval'])
+                poles_dict['norm'].append(rec['norm'])
+                poles_dict['alpha'].append(rec['alpha'])
+                poles_dict['beta'].append(rec['beta'])
+
+            poles_all[iom][ipol] = poles_dict
+            rixs[iom, :, ipol] = get_spectra_from_poles(
+                poles_dict, eloss, gamma_final, temperature
+            )
+
+    print("edrixs >>> Krylov RIXS Done !")
+
+    if return_poles:
+        return rixs, poles_all
+    return rixs
+
+
+def _rixs_krylov_one_contribution_scipy(*, hmat_i, hmat_n, trans_op_H, polvec_f,
+                                        eval_i, evec_i, istate, omega, gamma_c,
+                                        rhs, skip_gs, nkryl, linsys_tol,
+                                        linsys_maxiter, linsys_restart):
+    """Compute one kept-initial-state contribution to one RIXS pole dictionary."""
+    Ei = eval_i[istate]
+
+    if np.linalg.norm(rhs) == 0:
+        alpha = np.array([0.0], dtype=float)
+        beta = np.array([], dtype=float)
+        return {
+            'eigval': Ei,
+            'npoles': 1,
+            'norm': 0.0,
+            'alpha': alpha,
+            'beta': beta
+        }
+
+    z = omega + Ei + 1j * gamma_c
+
+    A = LinearOperator(
+        shape=hmat_n.shape,
+        matvec=lambda x, z=z: z * x - hmat_n @ x,
+        dtype=np.complex128
+    )
+
+    x, info = _gmres_scipy_compat(
+        A, rhs, tol=linsys_tol, restart=linsys_restart, maxiter=linsys_maxiter
+    )
+
+    if info != 0:
+        raise RuntimeError(
+            "GMRES did not converge for istate={}, omega={}; info={}".format(
+                istate, omega, info
+            )
+        )
+
+    phi_vec = _apply_linear_combination(trans_op_H, np.conj(polvec_f), x)
+
+    if skip_gs:
+        for j in range(len(eval_i)):
+            gj = evec_i[:, j]
+            phi_vec = phi_vec - gj * np.vdot(gj, phi_vec)
+
+    if np.linalg.norm(phi_vec) == 0:
+        alpha = np.array([0.0], dtype=float)
+        beta = np.array([], dtype=float)
+        norm = 0.0
+    else:
+        alpha, beta, norm = lanczos_tridiagonal(hmat_i, phi_vec, m=nkryl)
+
+    return {
+        'eigval': Ei,
+        'npoles': len(alpha),
+        'norm': norm,
+        'alpha': alpha,
+        'beta': beta
+    }
+
+
+def _rixs_polarization_vectors(ntrans, thin, thout, phi, it, alpha, jt, beta, scatter_axis):
+    """Return incoming and outgoing polarization vectors in transition-operator space."""
+    ei, ef = dipole_polvec_rixs(thin, thout, phi, alpha, beta, scatter_axis, (it, jt))
+
+    if it.lower() == 'isotropic':
+        ei = np.ones(3, dtype=complex) / np.sqrt(3.0)
+    if jt.lower() == 'isotropic':
+        ef = np.ones(3, dtype=complex) / np.sqrt(3.0)
+
+    polvec_i = np.zeros(ntrans, dtype=complex)
+    polvec_f = np.zeros(ntrans, dtype=complex)
+
+    if ntrans == 3:
+        polvec_i[:] = ei
+        polvec_f[:] = ef
+    elif ntrans == 5:
+        ki = unit_wavevector(thin, phi, scatter_axis, direction='in')
+        kf = unit_wavevector(thout, phi, scatter_axis, direction='out')
+        polvec_i[:] = quadrupole_polvec(ei, ki)
+        polvec_f[:] = quadrupole_polvec(ef, kf)
+    else:
+        raise ValueError("ntrans must be 3 or 5")
+
+    return polvec_i, polvec_f
+
+
+def _apply_linear_combination(ops, coeffs, vec):
+    """Apply sum_i coeffs[i] ops[i] to vec without constructing the summed operator."""
+    out = None
+    for coeff, op in zip(coeffs, ops):
+        if coeff == 0:
+            continue
+        term = coeff * (op @ vec)
+        out = term if out is None else out + term
+
+    if out is None:
+        return np.zeros(ops[0].shape[0], dtype=complex)
+    return out
+
+
+def _check_adjoint_action(op, name):
+    """Require op.H @ x to work."""
+    try:
+        test_vec = np.zeros(op.shape[0], dtype=complex)
+        _ = op.H @ test_vec
+    except Exception as exc:
+        raise TypeError(
+            "{} must provide an adjoint action. For a custom LinearOperator, "
+            "define rmatvec or _adjoint.".format(name)
+        ) from exc
+
+
+def _expand_broadening(gamma, n, name):
+    """Return gamma as a length-n float array."""
+    out = np.empty(n, dtype=float)
+    if np.isscalar(gamma):
+        out[:] = gamma
+    else:
+        gamma = np.asarray(gamma, dtype=float)
+        if gamma.shape != (n,):
+            raise ValueError("{} must be scalar or have shape ({},)".format(name, n))
+        out[:] = gamma
+    return out
+
+
+def _gmres_scipy_compat(A, b, *, tol, restart, maxiter):
+    """Call scipy.sparse.linalg.gmres with either old or new SciPy tolerance names."""
+    sig = inspect.signature(gmres)
+
+    if "rtol" in sig.parameters:
+        return gmres(A, b, rtol=tol, atol=0.0, restart=restart, maxiter=maxiter)
+
+    return gmres(A, b, tol=tol, restart=restart, maxiter=maxiter)
+
 
 
 def ed_1v1c_py(shell_name, *, shell_level=None, v_soc=None, c_soc=0,

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -1,8 +1,10 @@
-__all__ = ['Ops_1v1c_scipy','ed_krylov_scipy', 'rixs_krylov_scipy',
-           'ed_1v1c_py', 'xas_1v1c_py', 'rixs_1v1c_py',
-           'ed_1v1c_fort', 'xas_1v1c_fort', 'rixs_1v1c_fort',
-           'ed_2v1c_fort', 'xas_2v1c_fort', 'rixs_2v1c_fort',
-           'ed_siam_fort', 'xas_siam_fort', 'rixs_siam_fort']
+__all__ = [
+    'Ops_1v1c_scipy', 'ed_krylov_scipy', 'rixs_krylov_scipy',
+    'ed_1v1c_py', 'xas_1v1c_py', 'rixs_1v1c_py',
+    'ed_1v1c_fort', 'xas_1v1c_fort', 'rixs_1v1c_fort',
+    'ed_2v1c_fort', 'xas_2v1c_fort', 'rixs_2v1c_fort',
+    'ed_siam_fort', 'xas_siam_fort', 'rixs_siam_fort'
+]
 
 import numpy as np
 import scipy
@@ -30,10 +32,11 @@ from .soc import atom_hsoc
 from .krylov import lanczos_tridiagonal
 from .manybody_operator_csr import two_fermion_csr, four_fermion_csr
 
+
 def Ops_1v1c_scipy(shell_name, *, shell_level=None, v_soc=None, c_soc=0,
-                v_noccu=1, slater=None, ext_B=None, on_which='spin',
-                v_cfmat=None, v_othermat=None, loc_axis=None, verbose=0,
-                csr=True):
+                    v_noccu=1, slater=None, ext_B=None, on_which='spin',
+                    v_cfmat=None, v_othermat=None, loc_axis=None, verbose=0,
+                    csr=True):
     """
     Assemble sparse one-valence-one-core RIXS operators for Krylov solvers.
 
@@ -244,6 +247,7 @@ def Ops_1v1c_scipy(shell_name, *, shell_level=None, v_soc=None, c_soc=0,
 
     return hmat_i, hmat_n, trans_ops
 
+
 def ed_krylov_scipy(hmat_i, num_gs=1, blocksize=None, *,
                     tol=1e-10, maxiter=200,
                     seed=None, initial_guess=None, suppress_lobpcg_warnings=True):
@@ -359,6 +363,7 @@ def ed_krylov_scipy(hmat_i, num_gs=1, blocksize=None, *,
     evec_i = np.asarray(evecs)[:, order[:num_gs]]
 
     return eval_i, evec_i
+
 
 def rixs_krylov_scipy(eval_i, evec_i, hmat_i, hmat_n, trans_op, ominc, eloss, *,
                       gamma_c=0.1, gamma_f=0.01, thin=1.0, thout=1.0, phi=0.0,
@@ -659,7 +664,6 @@ def _gmres_scipy_compat(A, b, *, tol, restart, maxiter):
         return gmres(A, b, rtol=tol, atol=0.0, restart=restart, maxiter=maxiter)
 
     return gmres(A, b, tol=tol, restart=restart, maxiter=maxiter)
-
 
 
 def ed_1v1c_py(shell_name, *, shell_level=None, v_soc=None, c_soc=0,

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -1,6 +1,6 @@
 __all__ = [
     'setup_1v1c', 'ops', 'ed_krylov_scipy', 'rixs_krylov_scipy',
-    'setup_2v1c','setup_siam',
+    'setup_2v1c', 'setup_siam',
     'ed_1v1c_py', 'xas_1v1c_py', 'rixs_1v1c_py',
     'ed_1v1c_fort', 'xas_1v1c_fort', 'rixs_1v1c_fort',
     'ed_2v1c_fort', 'xas_2v1c_fort', 'rixs_2v1c_fort',
@@ -831,6 +831,7 @@ def _embed_impurity_core_umat(umat_tmp, v_norb, c_norb, ntot_v):
                     umat[idx[i], idx[j], idx[k], idx[m]] = umat_tmp[i, j, k, m]
 
     return umat
+
 
 def ops(emat_i, umat_i, basis_i, emat_n, umat_n, basis_n, trans_mat,
         *, backend='scipy', tol=1E-10):

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -13,7 +13,6 @@ import scipy.sparse as sp
 from scipy.sparse.linalg import LinearOperator, aslinearoperator, lobpcg, gmres
 import inspect
 import warnings
-from collections import defaultdict
 
 from .iostream import (
     write_tensor, write_emat, write_umat, write_config, read_poles_from_file
@@ -33,7 +32,9 @@ from .rixs_utils import scattering_mat
 from .plot_spectrum import get_spectra_from_poles, merge_pole_dicts
 from .soc import atom_hsoc
 from .krylov import lanczos_tridiagonal
-from .manybody_operator_csr import two_fermion_csr, four_fermion_csr
+from .manybody_operator_csr import (
+    two_fermion_csr, four_fermion_csr_auto, get_fock_basis_int
+)
 
 
 def setup_1v1c(shell_name, *, shell_level=None, v_soc=None, c_soc=0,
@@ -195,8 +196,8 @@ def setup_1v1c(shell_name, *, shell_level=None, v_soc=None, c_soc=0,
         write_emat(emat_n, 'hopping_n.in')
 
     # Fock bases.
-    basis_i = get_fock_bin_by_N(v_norb, v_noccu, c_norb, c_norb)
-    basis_n = get_fock_bin_by_N(v_norb, v_noccu + 1, c_norb, c_norb - 1)
+    basis_i = get_fock_basis_int(v_norb, v_noccu, c_norb, c_norb)
+    basis_n = get_fock_basis_int(v_norb, v_noccu + 1, c_norb, c_norb - 1)
 
     print("edrixs >>> Dimension of the initial Hamiltonian: ", len(basis_i))
     print("edrixs >>> Dimension of the intermediate Hamiltonian: ", len(basis_n))
@@ -434,10 +435,10 @@ def setup_2v1c(
         write_emat(emat_i, 'hopping_i.in')
         write_emat(emat_n, 'hopping_n.in')
 
-    basis_i = get_fock_bin_by_N(
+    basis_i = get_fock_basis_int(
         v1v2_norb, v_tot_noccu, c_norb, c_norb
     )
-    basis_n = get_fock_bin_by_N(
+    basis_n = get_fock_basis_int(
         v1v2_norb, v_tot_noccu + 1, c_norb, c_norb - 1
     )
 
@@ -657,8 +658,8 @@ def setup_siam(
         write_emat(emat_i, 'hopping_i.in')
         write_emat(emat_n, 'hopping_n.in')
 
-    basis_i = get_fock_bin_by_N(ntot_v, v_noccu, c_norb, c_norb)
-    basis_n = get_fock_bin_by_N(ntot_v, v_noccu + 1, c_norb, c_norb - 1)
+    basis_i = get_fock_basis_int(ntot_v, v_noccu, c_norb, c_norb)
+    basis_n = get_fock_basis_int(ntot_v, v_noccu + 1, c_norb, c_norb - 1)
 
     print("edrixs >>> Dimension of the initial Hamiltonian: ", len(basis_i))
     print("edrixs >>> Dimension of the intermediate Hamiltonian: ", len(basis_n))
@@ -864,10 +865,10 @@ def ops(emat_i, umat_i, basis_i, emat_n, umat_n, basis_n, trans_mat,
     print("edrixs >>> Building many-body operators with backend='{}' ...".format(backend))
 
     hmat_i_sp = two_fermion_csr(emat_i, basis_i, basis_i, tol=tol)
-    hmat_i_sp = hmat_i_sp + _four_fermion_csr_auto(umat_i, basis_i, tol=tol)
+    hmat_i_sp = hmat_i_sp + four_fermion_csr_auto(umat_i, basis_i, tol=tol)
 
     hmat_n_sp = two_fermion_csr(emat_n, basis_n, basis_n, tol=tol)
-    hmat_n_sp = hmat_n_sp + _four_fermion_csr_auto(umat_n, basis_n, tol=tol)
+    hmat_n_sp = hmat_n_sp + four_fermion_csr_auto(umat_n, basis_n, tol=tol)
 
     trans_ops_sp = [
         two_fermion_csr(trans_mat[i], basis_n, basis_i, tol=tol).tocsr()
@@ -887,103 +888,6 @@ def ops(emat_i, umat_i, basis_i, emat_n, umat_n, basis_n, trans_mat,
         )
 
     return hmat_i_sp.toarray(), hmat_n_sp.toarray(), [T.toarray() for T in trans_ops_sp]
-
-
-def _four_fermion_csr_auto(umat, basis, rb=None, tol=1E-10):
-    """Dispatch four-fermion construction based on dense or sparse U format."""
-    if sp.issparse(umat):
-        return _four_fermion_csr_from_sparse_umat(umat, basis, rb=rb, tol=tol)
-
-    return four_fermion_csr(umat, basis, rb=rb, tol=tol)
-
-
-def _four_fermion_csr_from_sparse_umat(umat, lb, rb=None, tol=1E-10):
-    """
-    Build a four-fermion many-body operator from sparse flattened U.
-
-    The sparse U matrix must have shape (norbs*norbs, norbs*norbs), with
-
-        row = lorb * norbs + korb
-        col = jorb * norbs + iorb
-
-    representing tensor entries umat[lorb, korb, jorb, iorb].
-    """
-    if rb is None:
-        rb = lb
-
-    lb = np.asarray(lb)
-    rb = np.asarray(rb)
-
-    nr = len(rb)
-    nl = len(lb)
-    norbs = len(rb[0])
-
-    expected_shape = (norbs * norbs, norbs * norbs)
-    if umat.shape != expected_shape:
-        raise ValueError(
-            "sparse umat has shape {}, expected {}".format(
-                umat.shape, expected_shape
-            )
-        )
-
-    umat = umat.tocoo()
-
-    indx = defaultdict(lambda: -1)
-    for i, cfg in enumerate(lb):
-        indx[tuple(cfg)] = i
-
-    rows = []
-    cols = []
-    data = []
-
-    tmp_basis = np.zeros(norbs, dtype=rb.dtype)
-
-    for row, col, val in zip(umat.row, umat.col, umat.data):
-        if abs(val) <= tol:
-            continue
-
-        lorb = row // norbs
-        korb = row % norbs
-        jorb = col // norbs
-        iorb = col % norbs
-
-        if iorb == jorb or korb == lorb:
-            continue
-
-        for icfg in range(nr):
-            tmp_basis[:] = rb[icfg]
-
-            if tmp_basis[iorb] == 0:
-                continue
-            s1 = (-1)**np.count_nonzero(tmp_basis[0:iorb])
-            tmp_basis[iorb] = 0
-
-            if tmp_basis[jorb] == 0:
-                continue
-            s2 = (-1)**np.count_nonzero(tmp_basis[0:jorb])
-            tmp_basis[jorb] = 0
-
-            if tmp_basis[korb] == 1:
-                continue
-            s3 = (-1)**np.count_nonzero(tmp_basis[0:korb])
-            tmp_basis[korb] = 1
-
-            if tmp_basis[lorb] == 1:
-                continue
-            s4 = (-1)**np.count_nonzero(tmp_basis[0:lorb])
-            tmp_basis[lorb] = 1
-
-            jcfg = indx[tuple(tmp_basis)]
-            if jcfg != -1:
-                rows.append(jcfg)
-                cols.append(icfg)
-                data.append(val * s1 * s2 * s3 * s4)
-
-    return sp.coo_matrix(
-        (data, (rows, cols)),
-        shape=(nl, nr),
-        dtype=np.complex128
-    ).tocsr()
 
 
 def ed_krylov_scipy(hmat_i, num_gs=1, blocksize=None, *,

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -1,5 +1,6 @@
 __all__ = [
-    'Ops_1v1c_scipy', 'ed_krylov_scipy', 'rixs_krylov_scipy',
+    'setup_1v1c', 'ops', 'ed_krylov_scipy', 'rixs_krylov_scipy'
+    'setup_2v1c','setup_siam',
     'ed_1v1c_py', 'xas_1v1c_py', 'rixs_1v1c_py',
     'ed_1v1c_fort', 'xas_1v1c_fort', 'rixs_1v1c_fort',
     'ed_2v1c_fort', 'xas_2v1c_fort', 'rixs_2v1c_fort',
@@ -11,6 +12,7 @@ import scipy
 from scipy.sparse.linalg import LinearOperator, aslinearoperator, lobpcg, gmres
 import inspect
 import warnings
+from collections import defaultdict
 
 from .iostream import (
     write_tensor, write_emat, write_umat, write_config, read_poles_from_file
@@ -33,37 +35,44 @@ from .krylov import lanczos_tridiagonal
 from .manybody_operator_csr import two_fermion_csr, four_fermion_csr
 
 
-def Ops_1v1c_scipy(
-    shell_name, *, shell_level=None, v_soc=None, c_soc=0,
-    v_noccu=1, slater=None, ext_B=None, on_which='spin',
-    v_cfmat=None, v_othermat=None, loc_axis=None, verbose=0,
-    csr=True
-):
+def setup_1v1c(shell_name, *, shell_level=None, v_soc=None, c_soc=0,
+               v_noccu=1, slater=None, ext_B=None, on_which='spin',
+               v_cfmat=None, v_othermat=None, loc_axis=None, verbose=0,
+               sparse_U=False, tol=1E-10):
     """
-    Assemble sparse one-valence-one-core RIXS operators for Krylov solvers.
+    Set up orbital-space data and Fock bases for a 1v1c problem.
 
-    This routine mirrors the model-construction part of ed_1v1c_py, but it does
-    not diagonalize either Hamiltonian and it does not transform transition
-    operators to an eigenbasis.
+    This routine defines the physical one-valence-shell/one-core-shell problem
+    independently of the numerical backend. It constructs the one-body orbital
+    matrices, Coulomb tensors, Fock bases, and orbital-space transition
+    matrices, but it does not build many-body Hamiltonians and does not
+    diagonalize anything.
+
+    Parameters
+    ----------
+    shell_name : tuple of str
+        Names of the valence and core shells.
+
+    shell_level, v_soc, c_soc, v_noccu, slater, ext_B, on_which,
+    v_cfmat, v_othermat, loc_axis, verbose
+        Same physical model parameters as ed_1v1c_py.
+
+    sparse_U : bool, optional
+        If False, return dense rank-4 Coulomb tensors. If True, return each
+        Coulomb tensor as a sparse matrix with shape (ntot*ntot, ntot*ntot),
+        using the flattened convention
+        row = lorb * ntot + korb and col = jorb * ntot + iorb.
+
+    tol : float, optional
+        Threshold used when converting dense Coulomb tensors to sparse format.
 
     Returns
     -------
-    hmat_i : scipy.sparse.linalg.LinearOperator
-        Initial/final many-body Hamiltonian in the initial Fock basis.
-
-    hmat_n : scipy.sparse.linalg.LinearOperator
-        Intermediate many-body Hamiltonian in the intermediate Fock basis.
-
-    trans_ops : list of scipy.sparse.linalg.LinearOperator
-        Transition operators in the many-body basis.  Each operator maps from
-        the initial Hilbert space to the intermediate Hilbert space and has
-        shape (dim_n, dim_i).  The list has length 3 for dipole transitions or
-        length 5 for quadrupole transitions.
+    emat_i, umat_i, basis_i, emat_n, umat_n, basis_n, trans_mat
+        Backend-independent problem definition. trans_mat has shape
+        (npol, ntot, ntot).
     """
-    if csr is not True:
-        raise ValueError("Ops_1v1c_sp always builds sparse CSR operators; use csr=True")
-
-    print("edrixs >>> Building sparse 1v1c operators ...")
+    print("edrixs >>> Setting up 1v1c problem ...")
 
     v_name_options = ['s', 'p', 't2g', 'd', 'f']
     c_name_options = ['s', 'p', 'p12', 'p32', 't2g', 'd', 'd32', 'd52',
@@ -122,6 +131,10 @@ def Ops_1v1c_scipy(
     if verbose > 0:
         write_umat(umat_i, 'coulomb_i.in')
         write_umat(umat_n, 'coulomb_n.in')
+
+    if sparse_U:
+        umat_i = _umat_dense_to_sparse(umat_i, tol=tol)
+        umat_n = _umat_dense_to_sparse(umat_n, tol=tol)
 
     # Spin-orbit coupling.
     if v_soc is not None:
@@ -184,25 +197,8 @@ def Ops_1v1c_scipy(
     basis_i = get_fock_bin_by_N(v_norb, v_noccu, c_norb, c_norb)
     basis_n = get_fock_bin_by_N(v_norb, v_noccu + 1, c_norb, c_norb - 1)
 
-    ncfg_i = len(basis_i)
-    ncfg_n = len(basis_n)
-
-    print("edrixs >>> Dimension of the initial Hamiltonian: ", ncfg_i)
-    print("edrixs >>> Dimension of the intermediate Hamiltonian: ", ncfg_n)
-
-    # Sparse many-body Hamiltonians in the Fock bases.
-    print("edrixs >>> Building sparse many-body Hamiltonians ...")
-
-    hmat_i_sp = two_fermion_csr(emat_i, basis_i, basis_i)
-    hmat_i_sp = hmat_i_sp + four_fermion_csr(umat_i, basis_i)
-
-    hmat_n_sp = two_fermion_csr(emat_n, basis_n, basis_n)
-    hmat_n_sp = hmat_n_sp + four_fermion_csr(umat_n, basis_n)
-
-    hmat_i_sp = hmat_i_sp.tocsr()
-    hmat_n_sp = hmat_n_sp.tocsr()
-
-    print("edrixs >>> Done !")
+    print("edrixs >>> Dimension of the initial Hamiltonian: ", len(basis_i))
+    print("edrixs >>> Dimension of the intermediate Hamiltonian: ", len(basis_n))
 
     # Transition operators in local coordinates, rotated to global coordinates.
     if loc_axis is not None:
@@ -231,23 +227,762 @@ def Ops_1v1c_scipy(
     else:
         raise Exception("Have NOT implemented this case: ", npol)
 
-    print("edrixs >>> Building sparse transition operators ...")
-
-    trans_ops_sp = []
+    trans_mat = np.zeros((npol, ntot, ntot), dtype=complex)
     for i in range(npol):
-        trans_mat = np.zeros((ntot, ntot), dtype=complex)
-        trans_mat[0:v_norb, v_norb:ntot] = tmp_g[i]
-        trans_ops_sp.append(
-            two_fermion_csr(trans_mat, basis_n, basis_i).tocsr()
+        trans_mat[i, 0:v_norb, v_norb:ntot] = tmp_g[i]
+
+    print("edrixs >>> 1v1c setup Done !")
+
+    return emat_i, umat_i, basis_i, emat_n, umat_n, basis_n, trans_mat
+
+def setup_2v1c(
+    shell_name, *, shell_level=None,
+    v1_soc=None, v2_soc=None, c_soc=0, v_tot_noccu=1, slater=None,
+    v1_ext_B=None, v2_ext_B=None, v1_on_which='spin',
+    v2_on_which='spin', v1_cfmat=None, v2_cfmat=None,
+    v1_othermat=None, v2_othermat=None, hopping_v1v2=None,
+    trans_to_which=1, loc_axis=None, verbose=0, sparse_U=False, tol=1E-10
+):
+    """
+    Set up orbital-space data and Fock bases for a 2v1c problem.
+
+    This is the backend-neutral setup analogue of the 2-valence-shell,
+    1-core-shell Fortran ED/RIXS input construction.  It does not build
+    many-body Hamiltonians and does not diagonalize anything. If sparse_U=True,
+    the returned Coulomb tensors are sparse flattened matrices rather than
+    dense rank-4 arrays.
+
+    Returns
+    -------
+    emat_i, umat_i, basis_i, emat_n, umat_n, basis_n, trans_mat
+        These can be passed directly to ops(..., backend='scipy') or
+        ops(..., backend='dense').
+    """
+    print("edrixs >>> Setting up 2v1c problem ...")
+
+    v_name_options = ['s', 'p', 't2g', 'd', 'f']
+    c_name_options = [
+        's', 'p', 'p12', 'p32', 't2g', 'd', 'd32', 'd52',
+        'f', 'f52', 'f72'
+    ]
+
+    v1_name = shell_name[0].strip()
+    v2_name = shell_name[1].strip()
+    c_name = shell_name[2].strip()
+
+    if v1_name not in v_name_options:
+        raise Exception("NOT supported type of valence shell: ", v1_name)
+    if v2_name not in v_name_options:
+        raise Exception("NOT supported type of valence shell: ", v2_name)
+    if c_name not in c_name_options:
+        raise Exception("NOT supported type of core shell: ", c_name)
+
+    info_shell = info_atomic_shell()
+
+    v1_orbl = info_shell[v1_name][0]
+    v2_orbl = info_shell[v2_name][0]
+
+    v1_norb = info_shell[v1_name][1]
+    v2_norb = info_shell[v2_name][1]
+    c_norb = info_shell[c_name][1]
+
+    v1v2_norb = v1_norb + v2_norb
+    ntot = v1v2_norb + c_norb
+
+    slater_name = slater_integrals_name(
+        (v1_name, v2_name, c_name), ('v1', 'v2', 'c1')
+    )
+    nslat = len(slater_name)
+
+    slater_i = np.zeros(nslat, dtype=float)
+    slater_n = np.zeros(nslat, dtype=float)
+
+    if slater is not None:
+        if nslat > len(slater[0]):
+            slater_i[0:len(slater[0])] = slater[0]
+        else:
+            slater_i[:] = slater[0][0:nslat]
+
+        if nslat > len(slater[1]):
+            slater_n[0:len(slater[1])] = slater[1]
+        else:
+            slater_n[:] = slater[1][0:nslat]
+
+    print()
+    print("    Summary of Slater integrals:")
+    print("    ------------------------------")
+    print("    Terms,   Initial Hamiltonian,  Intermediate Hamiltonian")
+    for i in range(nslat):
+        print("    ", slater_name[i], ":  {:20.10f}{:20.10f}".format(
+            slater_i[i], slater_n[i]
+        ))
+    print()
+
+    umat_i = get_umat_slater_3shells(
+        (v1_name, v2_name, c_name), *slater_i
+    )
+    umat_n = get_umat_slater_3shells(
+        (v1_name, v2_name, c_name), *slater_n
+    )
+
+    if verbose > 0:
+        write_umat(umat_i, 'coulomb_i.in')
+        write_umat(umat_n, 'coulomb_n.in')
+
+    if sparse_U:
+        umat_i = _umat_dense_to_sparse(umat_i, tol=tol)
+        umat_n = _umat_dense_to_sparse(umat_n, tol=tol)
+
+    emat_i = np.zeros((ntot, ntot), dtype=complex)
+    emat_n = np.zeros((ntot, ntot), dtype=complex)
+
+    # Spin-orbit coupling.
+    if v1_soc is not None and v1_name in ['p', 'd', 't2g', 'f']:
+        emat_i[0:v1_norb, 0:v1_norb] += atom_hsoc(v1_name, v1_soc[0])
+        emat_n[0:v1_norb, 0:v1_norb] += atom_hsoc(v1_name, v1_soc[1])
+
+    if v2_soc is not None and v2_name in ['p', 'd', 't2g', 'f']:
+        emat_i[v1_norb:v1v2_norb, v1_norb:v1v2_norb] += atom_hsoc(
+            v2_name, v2_soc[0]
+        )
+        emat_n[v1_norb:v1v2_norb, v1_norb:v1v2_norb] += atom_hsoc(
+            v2_name, v2_soc[1]
         )
 
-    print("edrixs >>> Sparse operator assembly Done !")
+    if c_name in ['p', 'd', 'f']:
+        emat_n[v1v2_norb:ntot, v1v2_norb:ntot] += atom_hsoc(
+            c_name, c_soc
+        )
 
-    hmat_i = aslinearoperator(hmat_i_sp)
-    hmat_n = aslinearoperator(hmat_n_sp)
-    trans_ops = [aslinearoperator(T) for T in trans_ops_sp]
+    # Crystal fields.
+    if v1_cfmat is not None:
+        emat_i[0:v1_norb, 0:v1_norb] += np.asarray(v1_cfmat)
+        emat_n[0:v1_norb, 0:v1_norb] += np.asarray(v1_cfmat)
 
-    return hmat_i, hmat_n, trans_ops
+    if v2_cfmat is not None:
+        emat_i[v1_norb:v1v2_norb, v1_norb:v1v2_norb] += np.asarray(
+            v2_cfmat
+        )
+        emat_n[v1_norb:v1v2_norb, v1_norb:v1v2_norb] += np.asarray(
+            v2_cfmat
+        )
+
+    # Other one-body terms.
+    if v1_othermat is not None:
+        emat_i[0:v1_norb, 0:v1_norb] += np.asarray(v1_othermat)
+        emat_n[0:v1_norb, 0:v1_norb] += np.asarray(v1_othermat)
+
+    if v2_othermat is not None:
+        emat_i[v1_norb:v1v2_norb, v1_norb:v1v2_norb] += np.asarray(
+            v2_othermat
+        )
+        emat_n[v1_norb:v1v2_norb, v1_norb:v1v2_norb] += np.asarray(
+            v2_othermat
+        )
+
+    # Shell levels.  Since the setup/ops route keeps the core orbitals in the
+    # Fock basis, the filled core contribution is represented explicitly.
+    if shell_level is not None:
+        emat_i[0:v1_norb, 0:v1_norb] += np.eye(v1_norb) * shell_level[0]
+        emat_n[0:v1_norb, 0:v1_norb] += np.eye(v1_norb) * shell_level[0]
+
+        emat_i[v1_norb:v1v2_norb, v1_norb:v1v2_norb] += (
+            np.eye(v2_norb) * shell_level[1]
+        )
+        emat_n[v1_norb:v1v2_norb, v1_norb:v1v2_norb] += (
+            np.eye(v2_norb) * shell_level[1]
+        )
+
+        emat_i[v1v2_norb:ntot, v1v2_norb:ntot] += (
+            np.eye(c_norb) * shell_level[2]
+        )
+        emat_n[v1v2_norb:ntot, v1v2_norb:ntot] += (
+            np.eye(c_norb) * shell_level[2]
+        )
+
+    # Zeeman fields.
+    for name, lval, ext_B, which, i1, i2 in [
+        (v1_name, v1_orbl, v1_ext_B, v1_on_which, 0, v1_norb),
+        (
+            v2_name, v2_orbl, v2_ext_B, v2_on_which,
+            v1_norb, v1v2_norb
+        )
+    ]:
+        if ext_B is None:
+            continue
+
+        zeeman = _valence_zeeman_matrix(name, lval, ext_B, which)
+        emat_i[i1:i2, i1:i2] += zeeman
+        emat_n[i1:i2, i1:i2] += zeeman
+
+    # Hopping between the two valence shells.
+    if hopping_v1v2 is not None:
+        hopping_v1v2 = np.asarray(hopping_v1v2)
+        emat_i[0:v1_norb, v1_norb:v1v2_norb] += hopping_v1v2
+        emat_i[v1_norb:v1v2_norb, 0:v1_norb] += np.conj(
+            np.transpose(hopping_v1v2)
+        )
+
+        emat_n[0:v1_norb, v1_norb:v1v2_norb] += hopping_v1v2
+        emat_n[v1_norb:v1v2_norb, 0:v1_norb] += np.conj(
+            np.transpose(hopping_v1v2)
+        )
+
+    if verbose > 0:
+        write_emat(emat_i, 'hopping_i.in')
+        write_emat(emat_n, 'hopping_n.in')
+
+    basis_i = get_fock_bin_by_N(
+        v1v2_norb, v_tot_noccu, c_norb, c_norb
+    )
+    basis_n = get_fock_bin_by_N(
+        v1v2_norb, v_tot_noccu + 1, c_norb, c_norb - 1
+    )
+
+    print("edrixs >>> Dimension of the initial Hamiltonian: ", len(basis_i))
+    print("edrixs >>> Dimension of the intermediate Hamiltonian: ", len(basis_n))
+
+    if trans_to_which == 1:
+        case = v1_name + c_name
+        tmp_g = _rotated_transition_blocks(case, loc_axis)
+        trans_mat = np.zeros((tmp_g.shape[0], ntot, ntot), dtype=complex)
+        trans_mat[:, 0:v1_norb, v1v2_norb:ntot] = tmp_g
+    elif trans_to_which == 2:
+        case = v2_name + c_name
+        tmp_g = _rotated_transition_blocks(case, loc_axis)
+        trans_mat = np.zeros((tmp_g.shape[0], ntot, ntot), dtype=complex)
+        trans_mat[:, v1_norb:v1v2_norb, v1v2_norb:ntot] = tmp_g
+    else:
+        raise Exception("Unknown trans_to_which: ", trans_to_which)
+
+    print("edrixs >>> 2v1c setup Done !")
+
+    return emat_i, umat_i, basis_i, emat_n, umat_n, basis_n, trans_mat
+
+
+def setup_siam(
+    shell_name, nbath, *, siam_type=0, v_noccu=1, static_core_pot=0,
+    c_level=0, c_soc=0, trans_c2n=None, imp_mat=None, imp_mat_n=None,
+    bath_level=None, bath_level_n=None, hyb=None, hyb_n=None,
+    hopping=None, hopping_n=None, slater=None, ext_B=None,
+    on_which='spin', loc_axis=None, verbose=0, sparse_U=False, tol=1E-10
+):
+    """
+    Set up orbital-space data and Fock bases for a SIAM problem.
+
+    This is the backend-neutral setup analogue of ed_siam_fort. It does not
+    search over occupancies, does not build many-body Hamiltonians, and does not
+    diagonalize anything. The occupancy is the supplied v_noccu. If
+    sparse_U=True, the impurity+core Coulomb tensor is embedded directly into
+    the full SIAM orbital space as a sparse flattened matrix.
+
+    Returns
+    -------
+    emat_i, umat_i, basis_i, emat_n, umat_n, basis_n, trans_mat
+        These can be passed directly to ops(..., backend='scipy') or
+        ops(..., backend='dense').
+    """
+    print("edrixs >>> Setting up SIAM problem ...")
+
+    v_name_options = ['s', 'p', 't2g', 'd', 'f']
+    c_name_options = [
+        's', 'p', 'p12', 'p32', 't2g', 'd', 'd32', 'd52',
+        'f', 'f52', 'f72'
+    ]
+
+    v_name = shell_name[0].strip()
+    c_name = shell_name[1].strip()
+
+    if v_name not in v_name_options:
+        raise Exception("NOT supported type of valence shell: ", v_name)
+    if c_name not in c_name_options:
+        raise Exception("NOT supported type of core shell: ", c_name)
+
+    info_shell = info_atomic_shell()
+
+    v_orbl = info_shell[v_name][0]
+    v_norb = info_shell[v_name][1]
+    c_norb = info_shell[c_name][1]
+
+    ntot_v = v_norb * (nbath + 1)
+    ntot = ntot_v + c_norb
+
+    slater_name = slater_integrals_name((v_name, c_name), ('v', 'c'))
+    nslat = len(slater_name)
+
+    slater_i = np.zeros(nslat, dtype=float)
+    slater_n = np.zeros(nslat, dtype=float)
+
+    if slater is not None:
+        if nslat > len(slater[0]):
+            slater_i[0:len(slater[0])] = slater[0]
+        else:
+            slater_i[:] = slater[0][0:nslat]
+
+        if nslat > len(slater[1]):
+            slater_n[0:len(slater[1])] = slater[1]
+        else:
+            slater_n[:] = slater[1][0:nslat]
+
+    print()
+    print("    Summary of Slater integrals:")
+    print("    ------------------------------")
+    print("    Terms,   Initial Hamiltonian,  Intermediate Hamiltonian")
+    for i in range(nslat):
+        print("    ", slater_name[i], ":  {:20.10f}{:20.10f}".format(
+            slater_i[i], slater_n[i]
+        ))
+    print()
+
+    umat_tmp_i = get_umat_slater(v_name + c_name, *slater_i)
+    umat_tmp_n = get_umat_slater(v_name + c_name, *slater_n)
+
+    if sparse_U:
+        umat_i = _embed_impurity_core_umat_sparse(
+            umat_tmp_i, v_norb, c_norb, ntot_v, tol=tol
+        )
+        umat_n = _embed_impurity_core_umat_sparse(
+            umat_tmp_n, v_norb, c_norb, ntot_v, tol=tol
+        )
+    else:
+        umat_i = _embed_impurity_core_umat(
+            umat_tmp_i, v_norb, c_norb, ntot_v
+        )
+        umat_n = _embed_impurity_core_umat(
+            umat_tmp_n, v_norb, c_norb, ntot_v
+        )
+
+    if verbose > 0:
+        write_umat(umat_i, 'coulomb_i.in')
+        write_umat(umat_n, 'coulomb_n.in')
+
+    emat_i = np.zeros((ntot, ntot), dtype=complex)
+    emat_n = np.zeros((ntot, ntot), dtype=complex)
+
+    if siam_type == 1:
+        if hopping is not None:
+            emat_i[0:ntot_v, 0:ntot_v] += np.asarray(hopping)
+
+        if hopping_n is not None:
+            emat_n[0:ntot_v, 0:ntot_v] += np.asarray(hopping_n)
+        elif hopping is not None:
+            emat_n[0:ntot_v, 0:ntot_v] += np.asarray(hopping)
+
+    elif siam_type == 0:
+        if imp_mat is not None:
+            emat_i[0:v_norb, 0:v_norb] += np.asarray(imp_mat)
+
+        if imp_mat_n is not None:
+            emat_n[0:v_norb, 0:v_norb] += np.asarray(imp_mat_n)
+        elif imp_mat is not None:
+            emat_n[0:v_norb, 0:v_norb] += np.asarray(imp_mat)
+
+        if bath_level is not None:
+            for i in range(nbath):
+                for j in range(v_norb):
+                    idx = (i + 1) * v_norb + j
+                    emat_i[idx, idx] += bath_level[i, j]
+
+        if bath_level_n is not None:
+            for i in range(nbath):
+                for j in range(v_norb):
+                    idx = (i + 1) * v_norb + j
+                    emat_n[idx, idx] += bath_level_n[i, j]
+        elif bath_level is not None:
+            for i in range(nbath):
+                for j in range(v_norb):
+                    idx = (i + 1) * v_norb + j
+                    emat_n[idx, idx] += bath_level[i, j]
+
+        if hyb is not None:
+            for i in range(nbath):
+                for j in range(v_norb):
+                    idx1 = j
+                    idx2 = (i + 1) * v_norb + j
+                    emat_i[idx1, idx2] += hyb[i, j]
+                    emat_i[idx2, idx1] += np.conj(hyb[i, j])
+
+        if hyb_n is not None:
+            for i in range(nbath):
+                for j in range(v_norb):
+                    idx1 = j
+                    idx2 = (i + 1) * v_norb + j
+                    emat_n[idx1, idx2] += hyb_n[i, j]
+                    emat_n[idx2, idx1] += np.conj(hyb_n[i, j])
+        elif hyb is not None:
+            for i in range(nbath):
+                for j in range(v_norb):
+                    idx1 = j
+                    idx2 = (i + 1) * v_norb + j
+                    emat_n[idx1, idx2] += hyb[i, j]
+                    emat_n[idx2, idx1] += np.conj(hyb[i, j])
+
+    else:
+        raise Exception("Unknown siam_type: ", siam_type)
+
+    if c_name in ['p', 'd', 'f']:
+        emat_n[ntot_v:ntot, ntot_v:ntot] += atom_hsoc(c_name, c_soc)
+
+    # Static core-hole potential on the impurity in the intermediate state.
+    emat_n[0:v_norb, 0:v_norb] -= np.eye(v_norb) * static_core_pot
+
+    if trans_c2n is None:
+        trans_c2n = np.eye(v_norb, dtype=complex)
+    else:
+        trans_c2n = np.asarray(trans_c2n)
+
+    tmat = np.eye(ntot, dtype=complex)
+    for i in range(nbath + 1):
+        off = i * v_norb
+        tmat[off:off + v_norb, off:off + v_norb] = np.conj(
+            np.transpose(trans_c2n)
+        )
+
+    emat_i[:, :] = cb_op(emat_i, tmat)
+    emat_n[:, :] = cb_op(emat_n, tmat)
+
+    if ext_B is not None:
+        zeeman = _valence_zeeman_matrix(v_name, v_orbl, ext_B, on_which)
+        emat_i[0:v_norb, 0:v_norb] += zeeman
+        emat_n[0:v_norb, 0:v_norb] += zeeman
+
+    # Since the setup/ops route keeps the core orbitals in the Fock basis, the
+    # filled-core contribution is represented explicitly.
+    emat_i[ntot_v:ntot, ntot_v:ntot] += np.eye(c_norb) * c_level
+    emat_n[ntot_v:ntot, ntot_v:ntot] += np.eye(c_norb) * c_level
+
+    if verbose > 0:
+        write_emat(emat_i, 'hopping_i.in')
+        write_emat(emat_n, 'hopping_n.in')
+
+    basis_i = get_fock_bin_by_N(ntot_v, v_noccu, c_norb, c_norb)
+    basis_n = get_fock_bin_by_N(ntot_v, v_noccu + 1, c_norb, c_norb - 1)
+
+    print("edrixs >>> Dimension of the initial Hamiltonian: ", len(basis_i))
+    print("edrixs >>> Dimension of the intermediate Hamiltonian: ", len(basis_n))
+
+    tmp_g = _rotated_transition_blocks(v_name + c_name, loc_axis)
+    trans_mat = np.zeros((tmp_g.shape[0], ntot, ntot), dtype=complex)
+    trans_mat[:, 0:v_norb, ntot_v:ntot] = tmp_g
+
+    print("edrixs >>> SIAM setup Done !")
+
+    return emat_i, umat_i, basis_i, emat_n, umat_n, basis_n, trans_mat
+
+
+
+def _rotated_transition_blocks(case, loc_axis=None):
+    """
+    Build transition blocks in global coordinates for a shell-transition case.
+    """
+    if loc_axis is None:
+        loc_axis = np.eye(3)
+    else:
+        loc_axis = np.asarray(loc_axis)
+
+    tmp = get_trans_oper(case)
+    npol, n, m = tmp.shape
+    tmp_g = np.zeros((npol, n, m), dtype=complex)
+
+    if npol == 3:
+        for i in range(3):
+            for j in range(3):
+                tmp_g[i] += loc_axis[i, j] * tmp[j]
+    elif npol == 5:
+        alpha, beta, gamma = rmat_to_euler(loc_axis)
+        wignerD = get_wigner_dmat(4, alpha, beta, gamma)
+        rotmat = np.dot(
+            np.dot(tmat_r2c('d'), wignerD),
+            np.conj(np.transpose(tmat_r2c('d')))
+        )
+        for i in range(5):
+            for j in range(5):
+                tmp_g[i] += rotmat[i, j] * tmp[j]
+    else:
+        raise Exception("Have NOT implemented this case: ", npol)
+
+    return tmp_g
+
+
+def _valence_zeeman_matrix(shell_name, orbl, ext_B, on_which):
+    """
+    Build a Zeeman matrix for a valence shell.
+    """
+    if shell_name == 't2g':
+        lx, ly, lz = get_lx(1, True), get_ly(1, True), get_lz(1, True)
+        sx, sy, sz = get_sx(1), get_sy(1), get_sz(1)
+        lx, ly, lz = -lx, -ly, -lz
+    else:
+        lx, ly, lz = get_lx(orbl, True), get_ly(orbl, True), get_lz(orbl, True)
+        sx, sy, sz = get_sx(orbl), get_sy(orbl), get_sz(orbl)
+
+    if on_which.strip() == 'spin':
+        return ext_B[0] * (2 * sx) + ext_B[1] * (2 * sy) + ext_B[2] * (2 * sz)
+
+    if on_which.strip() == 'orbital':
+        return ext_B[0] * lx + ext_B[1] * ly + ext_B[2] * lz
+
+    if on_which.strip() == 'both':
+        return (
+            ext_B[0] * (lx + 2 * sx)
+            + ext_B[1] * (ly + 2 * sy)
+            + ext_B[2] * (lz + 2 * sz)
+        )
+
+    raise Exception("Unknown value of on_which", on_which)
+
+
+
+def _umat_dense_to_sparse(umat, tol=1E-10):
+    """
+    Convert a dense rank-4 Coulomb tensor to a sparse flattened matrix.
+
+    The flattening convention is
+
+        row = lorb * norbs + korb
+        col = jorb * norbs + iorb
+
+    corresponding to tensor entry umat[lorb, korb, jorb, iorb].
+    """
+    umat = np.asarray(umat)
+
+    if umat.ndim != 4:
+        raise ValueError("dense umat must be a rank-4 tensor")
+
+    norbs = umat.shape[0]
+    if umat.shape != (norbs, norbs, norbs, norbs):
+        raise ValueError("dense umat must have shape (n, n, n, n)")
+
+    lorb, korb, jorb, iorb = np.nonzero(np.abs(umat) > tol)
+
+    rows = lorb * norbs + korb
+    cols = jorb * norbs + iorb
+    data = umat[lorb, korb, jorb, iorb]
+
+    return sp.coo_matrix(
+        (data, (rows, cols)),
+        shape=(norbs * norbs, norbs * norbs),
+        dtype=np.complex128
+    ).tocsr()
+
+
+def _embed_impurity_core_umat_sparse(umat_tmp, v_norb, c_norb, ntot_v,
+                                     tol=1E-10):
+    """
+    Embed an impurity+core Coulomb tensor into full SIAM space sparsely.
+
+    The input umat_tmp is the dense tensor for the compact impurity+core
+    orbital space of size v_norb + c_norb. The returned object is a sparse
+    flattened matrix for the full SIAM space of size ntot_v + c_norb.
+
+    No dense full-space rank-4 tensor is allocated.
+    """
+    umat_tmp = np.asarray(umat_tmp)
+
+    nsmall = v_norb + c_norb
+    if umat_tmp.shape != (nsmall, nsmall, nsmall, nsmall):
+        raise ValueError(
+            "umat_tmp has shape {}, expected {}".format(
+                umat_tmp.shape, (nsmall, nsmall, nsmall, nsmall)
+            )
+        )
+
+    ntot = ntot_v + c_norb
+    index_map = np.array(
+        list(range(v_norb)) + [ntot_v + i for i in range(c_norb)],
+        dtype=int
+    )
+
+    a, b, c, d = np.nonzero(np.abs(umat_tmp) > tol)
+
+    lorb = index_map[a]
+    korb = index_map[b]
+    jorb = index_map[c]
+    iorb = index_map[d]
+
+    rows = lorb * ntot + korb
+    cols = jorb * ntot + iorb
+    data = umat_tmp[a, b, c, d]
+
+    return sp.coo_matrix(
+        (data, (rows, cols)),
+        shape=(ntot * ntot, ntot * ntot),
+        dtype=np.complex128
+    ).tocsr()
+
+
+def _embed_impurity_core_umat(umat_tmp, v_norb, c_norb, ntot_v):
+    """
+    Embed an impurity+core Coulomb tensor into the full SIAM orbital space.
+
+    The bath orbitals do not carry local Coulomb interactions in this SIAM
+    representation, so only impurity and core indices are populated.
+    """
+    ntot = ntot_v + c_norb
+    umat = np.zeros((ntot, ntot, ntot, ntot), dtype=complex)
+
+    idx = list(range(v_norb)) + [ntot_v + i for i in range(c_norb)]
+
+    for i in range(v_norb + c_norb):
+        for j in range(v_norb + c_norb):
+            for k in range(v_norb + c_norb):
+                for m in range(v_norb + c_norb):
+                    umat[idx[i], idx[j], idx[k], idx[m]] = umat_tmp[i, j, k, m]
+
+    return umat
+
+def ops(emat_i, umat_i, basis_i, emat_n, umat_n, basis_n, trans_mat,
+        *, backend='scipy', tol=1E-10):
+    """
+    Build many-body Hamiltonians and transition operators for a backend.
+
+    Parameters
+    ----------
+    emat_i, umat_i, basis_i, emat_n, umat_n, basis_n, trans_mat
+        Problem definition returned by setup_1v1c or a future setup_* routine.
+
+    backend : {'scipy', 'dense'}, optional
+        Backend used for the returned many-body operators.
+
+        - 'scipy': return SciPy LinearOperator objects backed by CSR matrices.
+        - 'dense': return dense NumPy arrays. The dense backend currently
+          builds CSR matrices first and then converts them to dense arrays.
+
+    tol : float, optional
+        Threshold for ignoring small matrix/tensor elements.
+
+    Returns
+    -------
+    hmat_i, hmat_n, trans_ops
+        Many-body initial/final Hamiltonian, intermediate Hamiltonian, and
+        transition operators for the selected backend.
+    """
+    if backend not in ('scipy', 'dense'):
+        raise ValueError("backend must be either 'scipy' or 'dense'")
+
+    print("edrixs >>> Building many-body operators with backend='{}' ...".format(backend))
+
+    hmat_i_sp = two_fermion_csr(emat_i, basis_i, basis_i, tol=tol)
+    hmat_i_sp = hmat_i_sp + _four_fermion_csr_auto(umat_i, basis_i, tol=tol)
+
+    hmat_n_sp = two_fermion_csr(emat_n, basis_n, basis_n, tol=tol)
+    hmat_n_sp = hmat_n_sp + _four_fermion_csr_auto(umat_n, basis_n, tol=tol)
+
+    trans_ops_sp = [
+        two_fermion_csr(trans_mat[i], basis_n, basis_i, tol=tol).tocsr()
+        for i in range(trans_mat.shape[0])
+    ]
+
+    hmat_i_sp = hmat_i_sp.tocsr()
+    hmat_n_sp = hmat_n_sp.tocsr()
+
+    print("edrixs >>> Many-body operator construction Done !")
+
+    if backend == 'scipy':
+        return (
+            aslinearoperator(hmat_i_sp),
+            aslinearoperator(hmat_n_sp),
+            [aslinearoperator(T) for T in trans_ops_sp],
+        )
+
+    return hmat_i_sp.toarray(), hmat_n_sp.toarray(), [T.toarray() for T in trans_ops_sp]
+
+
+def _four_fermion_csr_auto(umat, basis, rb=None, tol=1E-10):
+    """Dispatch four-fermion construction based on dense or sparse U format."""
+    if sp.issparse(umat):
+        return _four_fermion_csr_from_sparse_umat(umat, basis, rb=rb, tol=tol)
+
+    return four_fermion_csr(umat, basis, rb=rb, tol=tol)
+
+
+def _four_fermion_csr_from_sparse_umat(umat, lb, rb=None, tol=1E-10):
+    """
+    Build a four-fermion many-body operator from sparse flattened U.
+
+    The sparse U matrix must have shape (norbs*norbs, norbs*norbs), with
+
+        row = lorb * norbs + korb
+        col = jorb * norbs + iorb
+
+    representing tensor entries umat[lorb, korb, jorb, iorb].
+    """
+    if rb is None:
+        rb = lb
+
+    lb = np.asarray(lb)
+    rb = np.asarray(rb)
+
+    nr = len(rb)
+    nl = len(lb)
+    norbs = len(rb[0])
+
+    expected_shape = (norbs * norbs, norbs * norbs)
+    if umat.shape != expected_shape:
+        raise ValueError(
+            "sparse umat has shape {}, expected {}".format(
+                umat.shape, expected_shape
+            )
+        )
+
+    umat = umat.tocoo()
+
+    indx = defaultdict(lambda: -1)
+    for i, cfg in enumerate(lb):
+        indx[tuple(cfg)] = i
+
+    rows = []
+    cols = []
+    data = []
+
+    tmp_basis = np.zeros(norbs, dtype=rb.dtype)
+
+    for row, col, val in zip(umat.row, umat.col, umat.data):
+        if abs(val) <= tol:
+            continue
+
+        lorb = row // norbs
+        korb = row % norbs
+        jorb = col // norbs
+        iorb = col % norbs
+
+        if iorb == jorb or korb == lorb:
+            continue
+
+        for icfg in range(nr):
+            tmp_basis[:] = rb[icfg]
+
+            if tmp_basis[iorb] == 0:
+                continue
+            s1 = (-1)**np.count_nonzero(tmp_basis[0:iorb])
+            tmp_basis[iorb] = 0
+
+            if tmp_basis[jorb] == 0:
+                continue
+            s2 = (-1)**np.count_nonzero(tmp_basis[0:jorb])
+            tmp_basis[jorb] = 0
+
+            if tmp_basis[korb] == 1:
+                continue
+            s3 = (-1)**np.count_nonzero(tmp_basis[0:korb])
+            tmp_basis[korb] = 1
+
+            if tmp_basis[lorb] == 1:
+                continue
+            s4 = (-1)**np.count_nonzero(tmp_basis[0:lorb])
+            tmp_basis[lorb] = 1
+
+            jcfg = indx[tuple(tmp_basis)]
+            if jcfg != -1:
+                rows.append(jcfg)
+                cols.append(icfg)
+                data.append(val * s1 * s2 * s3 * s4)
+
+    return sp.coo_matrix(
+        (data, (rows, cols)),
+        shape=(nl, nr),
+        dtype=np.complex128
+    ).tocsr()
 
 
 def ed_krylov_scipy(hmat_i, num_gs=1, blocksize=None, *,

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -34,9 +34,9 @@ from .manybody_operator_csr import two_fermion_csr, four_fermion_csr
 
 
 def Ops_1v1c_scipy(shell_name, *, shell_level=None, v_soc=None, c_soc=0,
-                    v_noccu=1, slater=None, ext_B=None, on_which='spin',
-                    v_cfmat=None, v_othermat=None, loc_axis=None, verbose=0,
-                    csr=True):
+                 v_noccu=1, slater=None, ext_B=None, on_which='spin',
+                 v_cfmat=None, v_othermat=None, loc_axis=None, verbose=0,
+                 csr=True):
     """
     Assemble sparse one-valence-one-core RIXS operators for Krylov solvers.
 

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -33,10 +33,12 @@ from .krylov import lanczos_tridiagonal
 from .manybody_operator_csr import two_fermion_csr, four_fermion_csr
 
 
-def Ops_1v1c_scipy(shell_name, *, shell_level=None, v_soc=None, c_soc=0,
-                 v_noccu=1, slater=None, ext_B=None, on_which='spin',
-                 v_cfmat=None, v_othermat=None, loc_axis=None, verbose=0,
-                 csr=True):
+def Ops_1v1c_scipy(
+    shell_name, *, shell_level=None, v_soc=None, c_soc=0,
+    v_noccu=1, slater=None, ext_B=None, on_which='spin',
+    v_cfmat=None, v_othermat=None, loc_axis=None, verbose=0,
+    csr=True
+):
     """
     Assemble sparse one-valence-one-core RIXS operators for Krylov solvers.
 

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -236,6 +236,7 @@ def setup_1v1c(shell_name, *, shell_level=None, v_soc=None, c_soc=0,
 
     return emat_i, umat_i, basis_i, emat_n, umat_n, basis_n, trans_mat
 
+
 def setup_2v1c(
     shell_name, *, shell_level=None,
     v1_soc=None, v2_soc=None, c_soc=0, v_tot_noccu=1, slater=None,
@@ -671,7 +672,6 @@ def setup_siam(
     return emat_i, umat_i, basis_i, emat_n, umat_n, basis_n, trans_mat
 
 
-
 def _rotated_transition_blocks(case, loc_axis=None):
     """
     Build transition blocks in global coordinates for a shell-transition case.
@@ -731,7 +731,6 @@ def _valence_zeeman_matrix(shell_name, orbl, ext_B, on_which):
         )
 
     raise Exception("Unknown value of on_which", on_which)
-
 
 
 def _umat_dense_to_sparse(umat, tol=1E-10):

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -1,5 +1,5 @@
 __all__ = [
-    'setup_1v1c', 'ops', 'ed_krylov_scipy', 'rixs_krylov_scipy'
+    'setup_1v1c', 'ops', 'ed_krylov_scipy', 'rixs_krylov_scipy',
     'setup_2v1c','setup_siam',
     'ed_1v1c_py', 'xas_1v1c_py', 'rixs_1v1c_py',
     'ed_1v1c_fort', 'xas_1v1c_fort', 'rixs_1v1c_fort',
@@ -9,6 +9,7 @@ __all__ = [
 
 import numpy as np
 import scipy
+import scipy.sparse as sp
 from scipy.sparse.linalg import LinearOperator, aslinearoperator, lobpcg, gmres
 import inspect
 import warnings


### PR DESCRIPTION
Add sparse SciPy/Krylov RIXS route

This update adds an experimental sparse Krylov-based RIXS workflow alongside the existing full-diagonalization Python route.

The new route is intended for larger sparse Hamiltonians where full diagonalization of the intermediate-state Hamiltonian is impractical. Instead of diagonalizing the intermediate Hamiltonian, the solver evaluates the intermediate-state correction vector with GMRES and reconstructs the final-state energy-loss spectrum with Lanczos.

New files:

- `krylov.py`
  - Adds low-level Lanczos/Krylov utilities:
    - `lanczos_tridiagonal`
    - `resolvent_from_tridiag`
    - `spectral_function_from_tridiag`
  - Uses the convention \[ G(z) = <psi | (zI - H)^(-1) | psi> \] and \[ A(omega) = -Im G(omega + E0 + i eta) / pi. \]

- `manybody_operator_csr.py`
  - Adds sparse CSR versions of the many-body operator builders:
    - `two_fermion_csr`
    - `four_fermion_csr`
  - These are used to construct sparse Hamiltonians and transition operators without materializing dense many-body matrices.

New solver functionality:

- `Ops_1v1c_scipy`
  - Sparse/operator assembly helper for the 1v1c model.
  - Takes the same physical model parameters as `ed_1v1c_py`.
  - Builds the initial/final Hamiltonian, intermediate Hamiltonian, and many-body transition operators using CSR routines.
  - Returns:
    - `hmat_i`
    - `hmat_n`
    - `trans_ops`
  - These are returned as SciPy `LinearOperator` objects.

- `ed_krylov_scipy`
  - Computes only the retained low-energy initial states using SciPy LOBPCG.
  - Returns `eval_i, evec_i` for the retained initial-state manifold.
  - Uses `num_gs` to specify how many low-energy states to keep.
  - Uses `blocksize` to allow a larger LOBPCG block, which is useful for expected degeneracies.

- `rixs_krylov_scipy`
  - Sparse/Krylov RIXS solver.
  - Assumes `eval_i` and `evec_i` contain only the retained initial states.
  - For each incident energy, polarization, and retained initial state, it solves \[ [(\omega_{in} + E_i + i\Gamma_c)I - H_n] x = D_i |i> \] with GMRES.
  - It then forms \[ |\Phi_i> = D_f^\dagger x \] and computes the final-state loss spectrum by Lanczos tridiagonalization of `hmat_i`.
  - The resulting pole dictionaries are passed to the existing `get_spectra_from_poles` machinery.

The intended workflow is now:

```python
hmat_i, hmat_n, trans_ops = Ops_1v1c_scipy(...)
eval_i, evec_i = ed_krylov_scipy(hmat_i, num_gs=..., blocksize=...)
rixs = rixs_krylov_scipy(
    eval_i, evec_i, hmat_i, hmat_n, trans_ops, ominc, eloss, ...
)